### PR TITLE
fix(network): ignore connections from the node to itself

### DIFF
--- a/elfo-network/src/discovery.rs
+++ b/elfo-network/src/discovery.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use eyre::{ensure, eyre, Result, WrapErr};
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use quanta::Instant;
 use tracing::{debug, error, info, warn};
 


### PR DESCRIPTION
`alice` example with the following config:
```toml
[system.telemeters]
sink = "Prometheus"
address = "0.0.0.0:9100"

[system.dumpers]
path = "example.alice.{class}.dump"

[system.network]
listen = ["tcp://127.0.0.1:9200"]
# note that discovery is set to the same address as the listen section
discovery.predefined = ["tcp://127.0.0.1:9200"]
```

Results in the following behaviour:
```
2023-06-14 10:47:14.623828000  INFO [2478858310674023425] system.network.discovery - new connection established	peer=tcp://127.0.0.1:59137	role=Unknown
2023-06-14 10:47:14.623879000  INFO [2478858310674022401] system.network.discovery - new connection established	peer=tcp://127.0.0.1:9200	role=Control
2023-06-14 10:47:14.624362000 DEBUG [2478858310674022401] system.network.discovery - handshake succeeded	peer=tcp://127.0.0.1:59137	elapsed=435.83µs
2023-06-14 10:47:14.624374000 DEBUG [2478858310674022401] system.network.discovery - connection to self ignored	peer=tcp://127.0.0.1:59137
2023-06-14 10:47:14.624492000 DEBUG [2478858310674023425] system.network.discovery - handshake succeeded	peer=tcp://127.0.0.1:9200	elapsed=478.306µs
2023-06-14 10:47:14.624502000 DEBUG [2478858310674023425] system.network.discovery - connection to self ignored	peer=tcp://127.0.0.1:9200
```

`peer=tcp://127.0.0.1:59137` is the listener ignoring the request and `peer=tcp://127.0.0.1:9200` is the discovery ignoring the request.