### PR TITLE
feat(logger): implement logs truncation when line size limit exceedes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ license = "MIT"
 edition = "2021"
 readme = "README.md"
 
+[workspace.dependencies]
+bytesize = { version = "1.2.0", features = ["serde"] }
+
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 unreachable_pub = "warn"

--- a/elfo-dumper/Cargo.toml
+++ b/elfo-dumper/Cargo.toml
@@ -30,4 +30,4 @@ serde_json = "1.0.64"
 eyre = "0.6.5"
 parking_lot = "0.12"
 thread_local = "1.1.3"
-bytesize = { version = "1.2.0", features = ["serde"] }
+bytesize.workspace = true

--- a/elfo-logger/Cargo.toml
+++ b/elfo-logger/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 
 [features]
 tracing-log = [ "dep:tracing-log", "log" ]
-docsrs = []
 
 [dependencies]
 elfo-core = { version = "0.2.0-alpha.15", path = "../elfo-core", features = ["unstable"] }
@@ -38,7 +37,7 @@ metrics = "0.17"
 dashmap = "5"
 fxhash = "0.2.1"
 humantime = "2.1.0"
-bytesize = { version = "1.2.0", features = ["serde"] }
+bytesize.workspace = true
 
 [dev-dependencies]
 elfo-core = { version = "0.2.0-alpha.15", path = "../elfo-core", features = ["test-util"] }

--- a/elfo-logger/Cargo.toml
+++ b/elfo-logger/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [features]
 tracing-log = [ "dep:tracing-log", "log" ]
+docsrs = []
 
 [dependencies]
 elfo-core = { version = "0.2.0-alpha.15", path = "../elfo-core", features = ["unstable"] }
@@ -37,6 +38,7 @@ metrics = "0.17"
 dashmap = "5"
 fxhash = "0.2.1"
 humantime = "2.1.0"
+bytesize = { version = "1.2.0", features = ["serde"] }
 
 [dev-dependencies]
 elfo-core = { version = "0.2.0-alpha.15", path = "../elfo-core", features = ["test-util"] }

--- a/elfo-logger/src/actor.rs
+++ b/elfo-logger/src/actor.rs
@@ -134,7 +134,9 @@ impl Logger {
                 || self.do_format_event::<theme::PlainTheme, TruncateOnUnfit>(&event)
         };
 
-        if !successful {
+        if successful {
+            self.shared.pool.clear(event.payload_id);
+        } else {
             unreachable!("truncation must succeed")
         }
     }

--- a/elfo-logger/src/actor.rs
+++ b/elfo-logger/src/actor.rs
@@ -19,7 +19,7 @@ use crate::{
     config::{Config, Sink},
     filtering_layer::FilteringLayer,
     formatters::Formatter,
-    line_buffer::{BufferConfig, LineBuffer},
+    line_buffer::LineBuffer,
     line_transaction::{FailOnUnfit, Line as _, LineFactory, TruncateOnUnfit},
     theme, PreparedEvent, Shared,
 };
@@ -57,9 +57,7 @@ impl Logger {
         filtering_layer.configure(&ctx.config().targets);
         let buffer = LineBuffer::with_capacity(1024, {
             let cfg = ctx.config();
-            BufferConfig {
-                max_line_size: cfg.max_line_size.0 as _,
-            }
+            cfg.max_line_size.0 as _
         });
 
         Self {
@@ -109,10 +107,7 @@ impl Logger {
                             file = open_file(self.ctx.config()).await;
                             use_colors = can_use_colors(self.ctx.config());
                             self.filtering_layer.configure(&self.ctx.config().targets);
-                            self.buffer.configure(|cfg| {
-                                let actor_cfg = self.ctx.config();
-                                cfg.max_line_size = actor_cfg.max_line_size.0 as _;
-                            });
+                            self.buffer.configure(self.ctx.config().max_line_size.0 as _);
                         },
                         Terminate => {
                             // Close the channel and wait for the rest of the events.

--- a/elfo-logger/src/config.rs
+++ b/elfo-logger/src/config.rs
@@ -4,6 +4,8 @@ use fxhash::FxHashMap;
 use serde::{Deserialize, Deserializer};
 use tracing::metadata::LevelFilter;
 
+use crate::line_buffer::MaxLineSize;
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct Config {
     #[serde(default)]
@@ -11,6 +13,9 @@ pub(crate) struct Config {
     pub(crate) path: Option<PathBuf>,
     #[serde(default)]
     pub(crate) format: Format,
+
+    #[serde(default)]
+    pub(crate) max_line_size: Option<MaxLineSize>,
 
     #[serde(default)]
     pub(crate) targets: FxHashMap<String, LoggingTargetConfig>,

--- a/elfo-logger/src/config.rs
+++ b/elfo-logger/src/config.rs
@@ -16,6 +16,12 @@ pub struct Config {
     #[serde(default)]
     pub format: Format,
 
+    /// Size limit for each written log-line, in bytes.
+    /// If size exceeds the limit, it will be truncated in the following order:
+    ///
+    /// 1. Message with custom fields
+    /// 2. Meta-info (level, timestamp, ...)
+    /// 3. Meta-fields (location, module)
     #[serde(default = "default_max_line_size")]
     pub max_line_size: ByteSize,
 

--- a/elfo-logger/src/config.rs
+++ b/elfo-logger/src/config.rs
@@ -4,7 +4,7 @@ use fxhash::FxHashMap;
 use serde::{Deserialize, Deserializer};
 use tracing::metadata::LevelFilter;
 
-use crate::line_buffer::MaxLineSize;
+use bytesize::ByteSize;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Config {
@@ -14,8 +14,14 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) format: Format,
 
-    #[serde(default)]
-    pub(crate) max_line_size: Option<MaxLineSize>,
+    /// Size limit for each line wrote in the log. The limit is applied in the
+    /// following order:
+    ///
+    /// 1. Message (logged message)
+    /// 2. Fields (location and module)
+    /// 3. Meta-info (timestamp, log level, trace id)
+    #[serde(default = "default_max_line_size")]
+    pub(crate) max_line_size: ByteSize,
 
     #[serde(default)]
     pub(crate) targets: FxHashMap<String, LoggingTargetConfig>,
@@ -42,6 +48,10 @@ pub(crate) struct Format {
     #[serde(default)]
     pub(crate) with_module: bool,
     // TODO: colors
+}
+
+fn default_max_line_size() -> ByteSize {
+    ByteSize(u64::MAX)
 }
 
 // TODO: deduplicate with core

--- a/elfo-logger/src/config.rs
+++ b/elfo-logger/src/config.rs
@@ -1,3 +1,5 @@
+#![allow(unreachable_pub)] // docsrs
+
 use std::path::PathBuf;
 
 use fxhash::FxHashMap;
@@ -7,34 +9,28 @@ use tracing::metadata::LevelFilter;
 use bytesize::ByteSize;
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct Config {
+pub struct Config {
     #[serde(default)]
-    pub(crate) sink: Sink,
-    pub(crate) path: Option<PathBuf>,
+    pub sink: Sink,
+    pub path: Option<PathBuf>,
     #[serde(default)]
-    pub(crate) format: Format,
+    pub format: Format,
 
-    /// Size limit for each line wrote in the log. The limit is applied in the
-    /// following order:
-    ///
-    /// 1. Message (logged message)
-    /// 2. Fields (location and module)
-    /// 3. Meta-info (timestamp, log level, trace id)
     #[serde(default = "default_max_line_size")]
-    pub(crate) max_line_size: ByteSize,
+    pub max_line_size: ByteSize,
 
     #[serde(default)]
-    pub(crate) targets: FxHashMap<String, LoggingTargetConfig>,
+    pub targets: FxHashMap<String, LoggingTargetConfig>,
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct LoggingTargetConfig {
+pub struct LoggingTargetConfig {
     #[serde(deserialize_with = "deserialize_level_filter")]
-    pub(crate) max_level: LevelFilter,
+    pub max_level: LevelFilter,
 }
 
 #[derive(Debug, Default, PartialEq, Deserialize)]
-pub(crate) enum Sink {
+pub enum Sink {
     File,
     #[default]
     Stdout,
@@ -42,11 +38,11 @@ pub(crate) enum Sink {
 }
 
 #[derive(Debug, Deserialize, Default)]
-pub(crate) struct Format {
+pub struct Format {
     #[serde(default)]
-    pub(crate) with_location: bool,
+    pub with_location: bool,
     #[serde(default)]
-    pub(crate) with_module: bool,
+    pub with_module: bool,
     // TODO: colors
 }
 

--- a/elfo-logger/src/formatters.rs
+++ b/elfo-logger/src/formatters.rs
@@ -8,6 +8,26 @@ pub(crate) trait Formatter<T: ?Sized> {
     fn fmt(dest: &mut String, v: &T);
 }
 
+// DoNothing
+
+pub(crate) struct DoNothing;
+
+impl<T> Formatter<T> for DoNothing {
+    fn fmt(_dest: &mut String, _v: &T) {
+        // Apparentely does nothing
+    }
+}
+
+// ResetColors
+
+pub(crate) struct ResetColors;
+
+impl Formatter<()> for ResetColors {
+    fn fmt(dest: &mut String, _v: &()) {
+        dest.push_str("\x1b[0m");
+    }
+}
+
 // Rfc3339Weak
 
 pub(crate) struct Rfc3339Weak;

--- a/elfo-logger/src/formatters.rs
+++ b/elfo-logger/src/formatters.rs
@@ -14,15 +14,15 @@ pub(crate) struct DoNothing;
 
 impl<T> Formatter<T> for DoNothing {
     fn fmt(_dest: &mut String, _v: &T) {
-        // Apparentely does nothing
+        // Apparently does nothing
     }
 }
 
-// ResetColors
+// ResetStyle
 
-pub(crate) struct ResetColors;
+pub(crate) struct ResetStyle;
 
-impl Formatter<()> for ResetColors {
+impl Formatter<()> for ResetStyle {
     fn fmt(dest: &mut String, _v: &()) {
         dest.push_str("\x1b[0m");
     }

--- a/elfo-logger/src/lib.rs
+++ b/elfo-logger/src/lib.rs
@@ -24,6 +24,7 @@ mod actor;
 mod config;
 mod filtering_layer;
 mod formatters;
+mod line_buffer;
 mod printing_layer;
 mod stats;
 mod theme;

--- a/elfo-logger/src/lib.rs
+++ b/elfo-logger/src/lib.rs
@@ -18,13 +18,14 @@ use elfo_core::{tracing::TraceId, ActorMeta, Blueprint};
 
 use crate::{actor::Logger, filtering_layer::FilteringLayer, printing_layer::PrintingLayer};
 
-#[cfg(feature = "docsrs")]
-pub use crate::config::Config;
-
 pub use crate::actor::ReopenLogFile;
 
-mod actor;
+#[cfg(not(docsrs))]
 mod config;
+#[cfg(docsrs)]
+pub mod config;
+
+mod actor;
 mod filtering_layer;
 mod formatters;
 mod printing_layer;

--- a/elfo-logger/src/lib.rs
+++ b/elfo-logger/src/lib.rs
@@ -18,16 +18,21 @@ use elfo_core::{tracing::TraceId, ActorMeta, Blueprint};
 
 use crate::{actor::Logger, filtering_layer::FilteringLayer, printing_layer::PrintingLayer};
 
+#[cfg(feature = "docsrs")]
+pub use crate::config::Config;
+
 pub use crate::actor::ReopenLogFile;
 
 mod actor;
 mod config;
 mod filtering_layer;
 mod formatters;
-mod line_buffer;
 mod printing_layer;
 mod stats;
 mod theme;
+
+mod line_buffer;
+mod line_transaction;
 
 const CHANNEL_CAPACITY: usize = 128 * 1024;
 

--- a/elfo-logger/src/line_buffer.rs
+++ b/elfo-logger/src/line_buffer.rs
@@ -2,6 +2,21 @@ use std::mem;
 
 use crate::line_transaction::Line;
 
+// BufferConfiguration
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BufferConfig {
+    pub(crate) max_line_size: usize,
+}
+
+impl Default for BufferConfig {
+    fn default() -> Self {
+        Self {
+            max_line_size: usize::MAX,
+        }
+    }
+}
+
 // Repr
 
 #[derive(Debug)]
@@ -19,15 +34,11 @@ struct Repr<'a> {
 pub(crate) struct CurrentLine<'a>(Repr<'a>);
 
 impl<'a> Line for CurrentLine<'a> {
-    fn discard(self) {
-        self.0.buf.buffer.truncate(self.0.pre_start_buffer_size);
-
-        // It's okay to leak `CurrentLine` since it does not owns any resources, thus
-        // freeing us from keeping additional run-time information about line status
-        mem::forget(self);
+    fn try_commit(self) -> bool {
+        true
     }
 
-    fn total_wrote(&self) -> usize {
+    fn total_bytes(&self) -> usize {
         self.len()
     }
 
@@ -57,8 +68,8 @@ impl<'a> CurrentLine<'a> {
 impl<'a> CurrentLine<'a> {
     fn probe_size_limit(&mut self) {
         let len = self.len();
-        let mut need_to_erase = if len > self.0.buf.max_line_size {
-            len - self.0.buf.max_line_size
+        let mut need_to_erase = if len > self.0.buf.cfg.max_line_size {
+            len - self.0.buf.cfg.max_line_size
         } else {
             return;
         };
@@ -107,24 +118,35 @@ impl<'a> Drop for DirectWrite<'a> {
 }
 
 impl Line for DirectWrite<'_> {
-    fn discard(self) {
-        self.0.buf.buffer.truncate(self.0.pre_start_buffer_size);
+    fn try_commit(self) -> bool {
+        if self.total_bytes() > self.0.buf.cfg.max_line_size {
+            self.0.buf.buffer.truncate(self.0.pre_start_buffer_size);
+            // It's okay to leak the `DirectWrite`, since it does not own any resources
+            mem::forget(self);
 
-        mem::forget(self);
+            false
+        } else {
+            true
+        }
     }
 
-    fn total_wrote(&self) -> usize {
+    fn total_bytes(&self) -> usize {
         self.0.buf.buffer.len() - self.0.pre_start_buffer_size
     }
 
+    // Nope, clippy, this is how it is supposed to work
+
+    #[allow(clippy::misnamed_getters)]
     fn meta_mut(&mut self) -> &mut String {
         &mut self.0.buf.buffer
     }
 
+    #[allow(clippy::misnamed_getters)]
     fn payload_mut(&mut self) -> &mut String {
         &mut self.0.buf.buffer
     }
 
+    #[allow(clippy::misnamed_getters)]
     fn fields_mut(&mut self) -> &mut String {
         &mut self.0.buf.buffer
     }
@@ -132,31 +154,32 @@ impl Line for DirectWrite<'_> {
 
 // LineBuffer
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct LineBuffer {
     // Buffer will contain lines and partially written meta-info, such as `<timestamp> <level>
     // [<trace_id>]` `payload` and `fields` will be merged as soon as [`CurrentLine`] will be
     // finished
-    pub(crate) buffer: String,
-
+    buffer: String,
     payload: String,
     fields: String,
 
-    pub(crate) max_line_size: usize,
-}
-
-impl Default for LineBuffer {
-    fn default() -> Self {
-        Self::new(usize::MAX)
-    }
+    cfg: BufferConfig,
 }
 
 impl LineBuffer {
+    pub(crate) fn configure<O>(&mut self, f: impl FnOnce(&mut BufferConfig) -> O) -> O {
+        f(&mut self.cfg)
+    }
+
     /// Discards current buffers
     pub(crate) fn clear(&mut self) {
         self.buffer.clear();
         self.payload.clear();
         self.fields.clear();
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        self.buffer.as_str()
     }
 
     fn create_repr(&mut self) -> Repr<'_> {
@@ -175,29 +198,19 @@ impl LineBuffer {
         CurrentLine(self.create_repr())
     }
 
-    pub(crate) fn with_buffer_capacity(capacity: usize, max_line_size: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize, cfg: BufferConfig) -> Self {
         Self {
             buffer: String::with_capacity(capacity),
             payload: String::new(),
             fields: String::new(),
-            max_line_size,
-        }
-    }
-
-    pub(crate) const fn new(max_line_size: usize) -> Self {
-        Self {
-            buffer: String::new(),
-            payload: String::new(),
-            fields: String::new(),
-
-            max_line_size,
+            cfg,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CurrentLine, LineBuffer};
+    use super::{BufferConfig, CurrentLine, LineBuffer};
     use crate::line_transaction::Line as _;
 
     fn put_msg(mut line: CurrentLine<'_>, meta: &str, payload: &str, fields: &str) {
@@ -207,7 +220,12 @@ mod tests {
     }
 
     fn truncation_parametrized(limit: usize, cases: &[(&str, &str, &str, &str)]) {
-        let mut buffer = LineBuffer::new(limit);
+        let mut buffer = LineBuffer::with_capacity(
+            100,
+            BufferConfig {
+                max_line_size: limit,
+            },
+        );
         for (meta, payload, fields, expected) in cases {
             let line = buffer.new_line();
             let before = line.0.pre_start_buffer_size;
@@ -241,7 +259,7 @@ mod tests {
     // When using 0 as line size limit, buffer must contain only newlines
     #[test]
     fn test_always_empty_string() {
-        let mut buffer = LineBuffer::new(0);
+        let mut buffer = LineBuffer::with_capacity(100, BufferConfig { max_line_size: 0 });
         put_msg(buffer.new_line(), "Hello", "World", "!!!!");
         put_msg(
             buffer.new_line(),

--- a/elfo-logger/src/line_buffer.rs
+++ b/elfo-logger/src/line_buffer.rs
@@ -1,0 +1,146 @@
+use std::{mem, num::NonZeroUsize};
+
+// MaxLineSize
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[repr(transparent)]
+/// Max size of the log line, cannot be zero
+pub struct MaxLineSize(pub NonZeroUsize);
+
+// CurrentLine
+
+#[derive(Debug)]
+pub(crate) struct CurrentLine<'a> {
+    buffer: &'a mut LineBuffer,
+
+    // We don't wanna write unfinished data, so there must be a way to
+    // revert changes made by `CurrentLine`
+    pre_start_buffer_size: usize,
+}
+
+impl<'a> CurrentLine<'a> {
+    fn meta_len(&self) -> usize {
+        self.buffer.buffer.len() - self.pre_start_buffer_size
+    }
+
+    fn len(&self) -> usize {
+        self.meta_len() + self.buffer.payload.len() + self.buffer.fields.len()
+    }
+
+    pub(crate) fn payload_mut(&mut self) -> &mut String {
+        &mut self.buffer.buffer
+    }
+
+    pub(crate) fn buffer_mut(&mut self) -> &mut String {
+        &mut self.buffer.buffer
+    }
+
+    pub(crate) fn fields_mut(&mut self) -> &mut String {
+        &mut self.buffer.fields
+    }
+}
+
+impl<'a> CurrentLine<'a> {
+    fn probe_size_limit(&mut self) {
+        let len = self.len();
+        let mut need_to_erase =
+            if let Some(size_limit) = self.buffer.max_line_size.map(|l| l.0.get()) {
+                if len > size_limit {
+                    len - size_limit
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            };
+
+        let payload_len = self.buffer.payload.len();
+        let fields_len = self.buffer.fields.len();
+        let meta_len = self.meta_len();
+
+        let payload_part = payload_len.min(need_to_erase);
+        need_to_erase -= payload_part;
+        let fields_part = fields_len.min(need_to_erase);
+        need_to_erase -= fields_part;
+        let meta_part = meta_len.min(need_to_erase);
+
+        self.buffer.payload.truncate(payload_len - payload_part);
+        self.buffer.fields.truncate(fields_len - fields_part);
+        self.buffer
+            .buffer
+            .truncate(self.buffer.buffer.len() - meta_part);
+    }
+
+    pub(crate) fn finish(mut self) {
+        self.probe_size_limit();
+
+        self.buffer
+            .buffer
+            .reserve(self.buffer.payload.len() + self.buffer.fields.len());
+        self.buffer.buffer.extend(
+            self.buffer
+                .payload
+                .chars()
+                .chain(self.buffer.fields.chars())
+                .chain(std::iter::once('\n')),
+        );
+        // It's okay to leak `CurrentLine` since it does not owns any resources, thus
+        // freeing us from keeping additional run-time information about line status
+        mem::forget(self);
+    }
+}
+
+impl<'a> Drop for CurrentLine<'a> {
+    fn drop(&mut self) {
+        // It is guaranteed by contract that this drop will be called only when
+        self.buffer.buffer.truncate(self.pre_start_buffer_size);
+    }
+}
+
+// LineBuffer
+
+#[derive(Debug)]
+pub(crate) struct LineBuffer {
+    // Buffer will contain lines and partially written meta-info, such as `<timestamp> <level>
+    // [<trace_id>]` `payload` and `fields` will be merged as soon as [`CurrentLine`] will be
+    // finished
+    pub(crate) buffer: String,
+
+    payload: String,
+    fields: String,
+
+    pub(crate) max_line_size: Option<MaxLineSize>,
+}
+
+impl Default for LineBuffer {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl LineBuffer {
+    /// Discards current buffers
+    pub(crate) fn clear(&mut self) {
+        self.buffer.clear();
+        self.payload.clear();
+        self.fields.clear();
+    }
+
+    pub(crate) fn new_line(&mut self) -> CurrentLine<'_> {
+        let size = self.buffer.len();
+        CurrentLine {
+            buffer: self,
+            pre_start_buffer_size: size,
+        }
+    }
+
+    pub(crate) const fn new(max_line_size: Option<MaxLineSize>) -> Self {
+        Self {
+            buffer: String::new(),
+            payload: String::new(),
+            fields: String::new(),
+
+            max_line_size,
+        }
+    }
+}

--- a/elfo-logger/src/line_buffer.rs
+++ b/elfo-logger/src/line_buffer.rs
@@ -2,9 +2,9 @@ use std::{mem, num::NonZeroUsize};
 
 // MaxLineSize
 
+/// Max size of the log line, cannot be zero.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[repr(transparent)]
-/// Max size of the log line, cannot be zero
 pub(crate) struct MaxLineSize(pub(crate) NonZeroUsize);
 
 // CurrentLine

--- a/elfo-logger/src/line_buffer.rs
+++ b/elfo-logger/src/line_buffer.rs
@@ -5,7 +5,7 @@ use std::{mem, num::NonZeroUsize};
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[repr(transparent)]
 /// Max size of the log line, cannot be zero
-pub struct MaxLineSize(pub NonZeroUsize);
+pub(crate) struct MaxLineSize(pub(crate) NonZeroUsize);
 
 // CurrentLine
 
@@ -93,6 +93,7 @@ impl<'a> CurrentLine<'a> {
 impl<'a> Drop for CurrentLine<'a> {
     fn drop(&mut self) {
         // It is guaranteed by contract that this drop will be called only when
+        // line is unfinished, since [`CurrentLine::finish`] leaks [`CurrentLine`]
         self.buffer.buffer.truncate(self.pre_start_buffer_size);
     }
 }

--- a/elfo-logger/src/line_transaction.rs
+++ b/elfo-logger/src/line_transaction.rs
@@ -1,0 +1,58 @@
+use crate::line_buffer::{CurrentLine, DirectWrite};
+
+use super::line_buffer::LineBuffer;
+
+/// This is needed due to rust's closure lifetimes binding limitation. Consider,
+/// for example, the following implementation:
+/// ```no_compile
+/// triat LineFactory<'a>: FnOnce(&'a LineBuffer) -> Self::Line {
+///     type Line: Line + 'a;
+/// }
+/// ```
+///
+/// and the following signature:
+/// ```no_compile
+/// fn use_factory(buffer: &mut LineBuffer, f: impl for<'a> LineFactory<'a>);
+/// ```
+///
+/// Today, on stable, it's not possible, since rust can't infer that return type
+/// lifetime depends on `buffer`'s HRTB lifetime: `use_factory(&mut buffer,
+/// |buf: &mut LineBuffer| buf.direct_write())` - this will not compile.
+// This is silly fix
+pub(crate) trait LineFactory {
+    type Line<'a>: Line + 'a;
+    const STOP: bool;
+
+    fn create_line(buf: &mut LineBuffer) -> Self::Line<'_>;
+}
+
+pub(crate) struct TryDirectWrite;
+pub(crate) struct UseSlowPath;
+
+impl LineFactory for TryDirectWrite {
+    type Line<'a> = DirectWrite<'a>;
+
+    const STOP: bool = false;
+
+    fn create_line(buf: &mut LineBuffer) -> Self::Line<'_> {
+        buf.direct_write()
+    }
+}
+impl LineFactory for UseSlowPath {
+    type Line<'a> = CurrentLine<'a>;
+
+    const STOP: bool = true;
+
+    fn create_line(buf: &mut LineBuffer) -> Self::Line<'_> {
+        buf.new_line()
+    }
+}
+
+pub(crate) trait Line {
+    fn meta_mut(&mut self) -> &mut String;
+    fn payload_mut(&mut self) -> &mut String;
+    fn fields_mut(&mut self) -> &mut String;
+
+    fn total_wrote(&self) -> usize;
+    fn discard(self);
+}

--- a/elfo-logger/src/line_transaction.rs
+++ b/elfo-logger/src/line_transaction.rs
@@ -48,6 +48,5 @@ pub(crate) trait Line {
     fn payload_mut(&mut self) -> &mut String;
     fn fields_mut(&mut self) -> &mut String;
 
-    fn total_bytes(&self) -> usize;
     fn try_commit(self) -> bool;
 }

--- a/elfo-logger/src/line_transaction.rs
+++ b/elfo-logger/src/line_transaction.rs
@@ -1,4 +1,4 @@
-use crate::line_buffer::{CurrentLine, DirectWrite};
+use crate::line_buffer::{DirectWrite, TruncatingWrite};
 
 use super::line_buffer::LineBuffer;
 
@@ -36,10 +36,10 @@ impl LineFactory for FailOnUnfit {
     }
 }
 impl LineFactory for TruncateOnUnfit {
-    type Line<'a> = CurrentLine<'a>;
+    type Line<'a> = TruncatingWrite<'a>;
 
     fn create_line(buf: &mut LineBuffer) -> Self::Line<'_> {
-        buf.new_line()
+        buf.truncating_write()
     }
 }
 

--- a/elfo-logger/src/theme.rs
+++ b/elfo-logger/src/theme.rs
@@ -14,7 +14,7 @@ pub(crate) trait Theme {
     type Payload: Formatter<str>;
     type Location: Formatter<(&'static str, u32)>;
     type Module: Formatter<str>;
-    type ResetColors: Formatter<()>;
+    type ResetStyle: Formatter<()>;
 }
 
 pub(crate) struct PlainTheme;
@@ -25,7 +25,7 @@ impl Theme for PlainTheme {
     type Location = Location;
     type Module = Module;
     type Payload = Payload;
-    type ResetColors = DoNothing;
+    type ResetStyle = DoNothing;
     type Timestamp = Rfc3339Weak;
     type TraceId = EmptyIfNone<TraceId>;
 }
@@ -38,7 +38,7 @@ impl Theme for ColoredTheme {
     type Location = ColoredLocation;
     type Module = ColoredModule;
     type Payload = ColoredPayload;
-    type ResetColors = ResetColors;
+    type ResetStyle = ResetStyle;
     type Timestamp = Rfc3339Weak;
     type TraceId = EmptyIfNone<ColoredByHash<TraceId>>;
 }

--- a/elfo-logger/src/theme.rs
+++ b/elfo-logger/src/theme.rs
@@ -14,6 +14,7 @@ pub(crate) trait Theme {
     type Payload: Formatter<str>;
     type Location: Formatter<(&'static str, u32)>;
     type Module: Formatter<str>;
+    type ResetColors: Formatter<()>;
 }
 
 pub(crate) struct PlainTheme;
@@ -24,6 +25,7 @@ impl Theme for PlainTheme {
     type Location = Location;
     type Module = Module;
     type Payload = Payload;
+    type ResetColors = DoNothing;
     type Timestamp = Rfc3339Weak;
     type TraceId = EmptyIfNone<TraceId>;
 }
@@ -36,6 +38,7 @@ impl Theme for ColoredTheme {
     type Location = ColoredLocation;
     type Module = ColoredModule;
     type Payload = ColoredPayload;
+    type ResetColors = ResetColors;
     type Timestamp = Rfc3339Weak;
     type TraceId = EmptyIfNone<ColoredByHash<TraceId>>;
 }

--- a/examples/examples/usage/config.toml
+++ b/examples/examples/usage/config.toml
@@ -23,8 +23,8 @@
 #format.with_location = false
 #format.with_module = false
 ## Max size of each line, in bytes, when actual line size exceedes, its contents will be
-## truncated in the following order: payload, meta-info (level, timestamp, ...), fields (location, module)
-#max_line_size = 12345
+## truncated in the following order: message with custom fields, meta-info (level, timestamp, ...), meta-fields (location, module)
+#max_line_size = "1KiB"
 #
 # It's possible to set `max_level` for a specific target:
 #targets.hyper.max_level = "Trace"

--- a/examples/examples/usage/config.toml
+++ b/examples/examples/usage/config.toml
@@ -22,6 +22,9 @@
 #path = "example.log"
 #format.with_location = false
 #format.with_module = false
+## Max size of each line, in bytes, when actual line size exceedes, its contents will be
+## truncated in the following order: payload, meta-info (level, timestamp, ...), fields (location, module)
+#max_line_size = 12345
 #
 # It's possible to set `max_level` for a specific target:
 #targets.hyper.max_level = "Trace"

--- a/examples/examples/usage/config.toml
+++ b/examples/examples/usage/config.toml
@@ -22,8 +22,6 @@
 #path = "example.log"
 #format.with_location = false
 #format.with_module = false
-## Max size of each line, in bytes, when actual line size exceedes, its contents will be
-## truncated in the following order: message with custom fields, meta-info (level, timestamp, ...), meta-fields (location, module)
 #max_line_size = "1KiB"
 #
 # It's possible to set `max_level` for a specific target:


### PR DESCRIPTION
Adds `max_line_size` option to `logger` config. Truncation is performed in the following order:
1. `payload`
2. `meta` (timestamp, level, trace id)
3. `fields` (location, module)