### PR TITLE
Add ability to change network discovery configuration on the fly

### DIFF
--- a/elfo-network/src/config.rs
+++ b/elfo-network/src/config.rs
@@ -26,7 +26,7 @@ use serde::{
 ///     "uds:///tmp/sock"
 /// ]
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     /// A list of addresses to listen on.
     #[serde(default)]
@@ -59,7 +59,7 @@ pub struct Config {
 }
 
 /// Compression settings.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct CompressionConfig {
     /// Compression algorithm.
     #[serde(default)]
@@ -67,7 +67,7 @@ pub struct CompressionConfig {
 }
 
 /// Compression algorithms.
-#[derive(Debug, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Deserialize, Clone)]
 pub enum CompressionAlgorithm {
     /// LZ4 with default compression level.
     Lz4,
@@ -85,7 +85,7 @@ fn default_idle_timeout() -> Duration {
 }
 
 /// How to discover other nodes.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct DiscoveryConfig {
     /// Predefined list of transports to connect to.
     pub predefined: Vec<Transport>,

--- a/elfo-network/src/discovery/diff.rs
+++ b/elfo-network/src/discovery/diff.rs
@@ -1,0 +1,100 @@
+#[cfg_attr(test, derive(Debug))]
+pub(crate) struct Diff<T> {
+    pub(crate) new: Vec<T>,
+    pub(crate) removed: fxhash::FxHashSet<T>,
+}
+
+impl<T> Diff<T> {
+    pub(crate) fn make<'a, I>(old: fxhash::FxHashSet<T>, new: I) -> Self
+    where
+        T: std::hash::Hash + Eq + Clone + 'a,
+        I: IntoIterator<Item = &'a T>,
+    {
+        let mut new_items = Vec::new();
+        let mut removed = old;
+        // Iterate over `new` version, removing each item from the
+        // `removed` set. Thus, the `removed` set in the end will
+        // contain items which are present in `old`, but not present
+        // in `new` - those elements are removed.
+        for item in new {
+            // If `removed` set previously didn't contain the item, then
+            // it's new.
+            let had = removed.remove(item);
+            if !had {
+                new_items.push(item.clone());
+            }
+        }
+
+        Self {
+            new: new_items,
+            removed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<T: Eq + Ord + Clone> PartialEq for Diff<T> {
+        fn eq(&self, other: &Self) -> bool {
+            let mut lhs_new = self.new.clone();
+            let mut lhs_removed = self.removed.iter().cloned().collect::<Vec<_>>();
+
+            lhs_new.sort();
+            lhs_removed.sort();
+
+            let mut rhs_new = other.new.clone();
+            let mut rhs_removed = other.removed.iter().cloned().collect::<Vec<_>>();
+
+            rhs_new.sort();
+            rhs_removed.sort();
+
+            (lhs_new == rhs_new) && (lhs_removed == rhs_removed)
+        }
+    }
+    impl<T: Eq + Ord + Clone> Eq for Diff<T> {}
+
+    #[test]
+    fn diff_works() {
+        struct Input {
+            old: Vec<u64>,
+            new: Vec<u64>,
+            expected: Diff<u64>,
+        }
+
+        impl Input {
+            fn new(
+                old: impl AsRef<[u64]>,
+                new: impl AsRef<[u64]>,
+                expected: (impl AsRef<[u64]>, impl AsRef<[u64]>),
+            ) -> Self {
+                let old = old.as_ref();
+                let new = new.as_ref();
+                let (diff_new, diff_removed) = (expected.0.as_ref(), expected.1.as_ref());
+
+                Self {
+                    old: old.to_vec(),
+                    new: new.to_vec(),
+                    expected: Diff {
+                        new: diff_new.to_vec(),
+                        removed: diff_removed.iter().copied().collect(),
+                    },
+                }
+            }
+        }
+
+        let inputs = [
+            Input::new([], [], ([], [])),
+            Input::new([1, 2, 3], [1, 2, 3], ([], [])),
+            Input::new([1, 2, 3], [1, 3], ([], [2])),
+            Input::new([1, 2, 3], [1, 2, 3, 4], ([4], [])),
+            Input::new([1, 2, 3], [1, 3, 4], ([4], [2])),
+        ];
+        for Input { new, old, expected } in inputs {
+            let actual = Diff::make(old.into_iter().collect(), new.iter());
+
+            assert_eq!(expected, actual);
+        }
+    }
+}

--- a/elfo-network/src/discovery/mod.rs
+++ b/elfo-network/src/discovery/mod.rs
@@ -178,7 +178,7 @@ impl Discovery {
         let capabilities = self.get_capabilities();
 
         for transport in &self.cfg.listen {
-            let stream = socket::listen(&transport, node_no, launch_id, capabilities)
+            let stream = socket::listen(transport, node_no, launch_id, capabilities)
                 .await
                 .wrap_err_with(|| eyre!("cannot listen {}", transport))?
                 .filter_map(move |socket| async move {
@@ -669,10 +669,10 @@ mod tests {
                 let (diff_new, diff_removed) = (expected.0.as_ref(), expected.1.as_ref());
 
                 Self {
-                    old: old.iter().copied().collect(),
-                    new: new.iter().copied().collect(),
+                    old: old.to_vec(),
+                    new: new.to_vec(),
                     expected: Diff {
-                        new: diff_new.iter().copied().collect(),
+                        new: diff_new.to_vec(),
                         removed: diff_removed.iter().copied().collect(),
                     },
                 }

--- a/elfo-network/src/discovery/mod.rs
+++ b/elfo-network/src/discovery/mod.rs
@@ -19,6 +19,8 @@ use crate::{
     NetworkContext,
 };
 
+use diff::Diff;
+
 /// Initial window size of every flow.
 /// TODO: should be different for groups and actors.
 const INITIAL_WINDOW_SIZE: i32 = 100_000;
@@ -154,7 +156,7 @@ impl Discovery {
         } = old;
 
         {
-            let Diff { new, removed } = diff_owned(
+            let Diff { new, removed } = Diff::make(
                 predefined.into_iter().collect(),
                 self.ctx.config().discovery.predefined.iter(),
             );
@@ -584,37 +586,6 @@ async fn recv_regular<M: Message>(socket: &mut Socket, idle_timeout: Duration) -
     })
 }
 
-#[cfg_attr(test, derive(Debug))]
-struct Diff<T> {
-    new: Vec<T>,
-    removed: fxhash::FxHashSet<T>,
-}
-
-fn diff_owned<'a, T, I>(old: fxhash::FxHashSet<T>, new: I) -> Diff<T>
-where
-    T: std::hash::Hash + Eq + Clone + 'a,
-    I: IntoIterator<Item = &'a T>,
-{
-    let mut new_items = Vec::new();
-    let mut removed = old;
-    // Iterate over `new` version, removing each item from the
-    // `removed` set. Thus, the `removed` set in the end will
-    // contain items which are present in `old`, but not present
-    // in `new` - these elements are removed.
-    for item in new {
-        // If `removed` set previously didn't contain the item, then
-        // it's new.
-        let had = removed.remove(item);
-        if !had {
-            new_items.push(item.clone());
-        }
-    }
-    Diff {
-        new: new_items,
-        removed,
-    }
-}
-
 fn unexpected_message_error(envelope: Envelope, expected: &[&str]) -> eyre::Report {
     eyre!(
         "unexpected message: {}, expected: {}",
@@ -627,69 +598,4 @@ async fn timeout<T>(duration: Duration, fut: impl Future<Output = Result<T>>) ->
     tokio::time::timeout(duration, fut).await?
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    impl<T: Eq + Ord + Clone> PartialEq for Diff<T> {
-        fn eq(&self, other: &Self) -> bool {
-            let mut lhs_new = self.new.clone();
-            let mut lhs_removed = self.removed.iter().cloned().collect::<Vec<_>>();
-
-            lhs_new.sort();
-            lhs_removed.sort();
-
-            let mut rhs_new = other.new.clone();
-            let mut rhs_removed = other.removed.iter().cloned().collect::<Vec<_>>();
-
-            rhs_new.sort();
-            rhs_removed.sort();
-
-            (lhs_new == rhs_new) && (lhs_removed == rhs_removed)
-        }
-    }
-    impl<T: Eq + Ord + Clone> Eq for Diff<T> {}
-
-    #[test]
-    fn diff_works() {
-        struct Input {
-            old: Vec<u64>,
-            new: Vec<u64>,
-            expected: Diff<u64>,
-        }
-
-        impl Input {
-            fn new(
-                old: impl AsRef<[u64]>,
-                new: impl AsRef<[u64]>,
-                expected: (impl AsRef<[u64]>, impl AsRef<[u64]>),
-            ) -> Self {
-                let old = old.as_ref();
-                let new = new.as_ref();
-                let (diff_new, diff_removed) = (expected.0.as_ref(), expected.1.as_ref());
-
-                Self {
-                    old: old.to_vec(),
-                    new: new.to_vec(),
-                    expected: Diff {
-                        new: diff_new.to_vec(),
-                        removed: diff_removed.iter().copied().collect(),
-                    },
-                }
-            }
-        }
-
-        let inputs = [
-            Input::new([], [], ([], [])),
-            Input::new([1, 2, 3], [1, 2, 3], ([], [])),
-            Input::new([1, 2, 3], [1, 3], ([], [2])),
-            Input::new([1, 2, 3], [1, 2, 3, 4], ([4], [])),
-            Input::new([1, 2, 3], [1, 3, 4], ([4], [2])),
-        ];
-        for Input { new, old, expected } in inputs {
-            let actual = diff_owned(old.into_iter().collect(), new.iter());
-
-            assert_eq!(expected, actual);
-        }
-    }
-}
+mod diff;

--- a/elfo-network/src/discovery/mod.rs
+++ b/elfo-network/src/discovery/mod.rs
@@ -19,7 +19,9 @@ use crate::{
     NetworkContext,
 };
 
-use diff::Diff;
+use self::diff::Diff;
+
+mod diff;
 
 /// Initial window size of every flow.
 /// TODO: should be different for groups and actors.
@@ -166,7 +168,7 @@ impl Discovery {
 
             // FIXME: handle removal.
             if !removed.is_empty() {
-                error!(
+                warn!(
                     ?removed,
                     "got removal of several discovery.predefined entries, this is not supported as of now"
                 );
@@ -597,5 +599,3 @@ fn unexpected_message_error(envelope: Envelope, expected: &[&str]) -> eyre::Repo
 async fn timeout<T>(duration: Duration, fut: impl Future<Output = Result<T>>) -> Result<T> {
     tokio::time::timeout(duration, fut).await?
 }
-
-mod diff;


### PR DESCRIPTION
This PR adds ability to change some `elfo-network` configuration aspects on the fly, more precisely - discovery settings.