### PR TITLE
feat(dumper): implement `time` in dump path template

### DIFF
--- a/elfo-dumper/Cargo.toml
+++ b/elfo-dumper/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.64"
 eyre = "0.6.5"
 parking_lot = "0.12"
 thread_local = "1.1.3"
+libc = "0.2.169"
 
 [dev-dependencies]
 elfo-core = { version = "0.2.0-alpha.17", path = "../elfo-core", features = ["test-util"] }

--- a/elfo-dumper/src/actor.rs
+++ b/elfo-dumper/src/actor.rs
@@ -89,7 +89,7 @@ impl Dumper {
         let ts = now
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("shit happens")
-            .as_secs();
+            .as_secs() as i64;
 
         TemplateVariables {
             class: self.ctx.key(),
@@ -165,7 +165,10 @@ impl Dumper {
                     // if variables aren't changed in the affectable way, it's
                     // not that matters here though.
                     self.render_path(&mut path_swap);
-                    let file = self.file_registry.acquire_for_write(&path, &mut path_swap).await?;
+                    let file = self
+                        .file_registry
+                        .acquire_for_write(&path, &mut path_swap)
+                        .await?;
                     if path != path_swap {
                         path.clear();
                         std::mem::swap(&mut path, &mut path_swap);

--- a/elfo-dumper/src/actor.rs
+++ b/elfo-dumper/src/actor.rs
@@ -167,7 +167,7 @@ impl Dumper {
                     self.render_path(&mut path_swap);
                     let file = self
                         .file_registry
-                        .acquire_for_write(&path, &mut path_swap)
+                        .acquire_for_write(&path, &path_swap)
                         .await?;
                     if path != path_swap {
                         path.clear();

--- a/elfo-dumper/src/config.rs
+++ b/elfo-dumper/src/config.rs
@@ -10,6 +10,10 @@ use std::time::Duration;
 use bytesize::ByteSize;
 use serde::Deserialize;
 
+pub(crate) mod dump_path;
+
+pub use dump_path::DumpPath;
+
 /// The dumper's config.
 ///
 /// # Examples
@@ -39,7 +43,7 @@ pub struct Config {
     /// A path to a dump file or template:
     /// * `path/all.dump` - one file.
     /// * `path/{class}.dump` - file per class.
-    pub path: String,
+    pub path: DumpPath,
     /// How often dumpers should write dumps to files.
     /// `500ms` by default.
     #[serde(with = "humantime_serde", default = "default_write_interval")]
@@ -102,12 +106,6 @@ pub enum OnOverflow {
     /// Truncate a dump, serialize as an incomplete JSON with appended
     /// `TRUNCATED`.
     Truncate,
-}
-
-impl Config {
-    pub(crate) fn path(&self, class: &str) -> String {
-        self.path.replace("{class}", class)
-    }
 }
 
 fn default_write_interval() -> Duration {

--- a/elfo-dumper/src/config.rs
+++ b/elfo-dumper/src/config.rs
@@ -43,6 +43,9 @@ pub struct Config {
     /// A path to a dump file or template:
     /// * `path/all.dump` - one file.
     /// * `path/{class}.dump` - file per class.
+    /// * `path/{time:<FORMAT>}.dump` - file per dump time. The `<FORMAT>`
+    ///   refers to the time format as in strftime:
+    ///   <https://cplusplus.com/reference/ctime/strftime/> (`man strftime(3)`).
     pub path: DumpPath,
     /// How often dumpers should write dumps to files.
     /// `500ms` by default.

--- a/elfo-dumper/src/config/dump_path.rs
+++ b/elfo-dumper/src/config/dump_path.rs
@@ -1,0 +1,273 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Variables for substitution in the path.
+#[derive(Debug)]
+pub(crate) struct TemplateVariables<'a> {
+    pub(crate) class: &'a str,
+    pub(crate) ts: u64,
+}
+
+/// Template for the dump path.
+#[derive(Debug)]
+pub struct DumpPath {
+    template: String,
+    /// Components of the template, contains instructions on
+    /// how to render.
+    // NOTE: ComponentData::Path cannot precede ComponentData::Path,
+    // it's done for efficiency purposes, but it isn't strict invariant.
+    components: Vec<Component>,
+}
+
+impl<'de> Deserialize<'de> for DumpPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::parse(s))
+    }
+}
+
+impl Serialize for DumpPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.template.serialize(serializer)
+    }
+}
+
+impl DumpPath {
+    fn expand_variable(var: Variable, vars: &TemplateVariables<'_>, dest: &mut String) {
+        match var {
+            Variable::Class => dest.push_str(vars.class),
+            Variable::Time => {
+                dest.push_str(&vars.ts.to_string());
+            }
+        }
+    }
+
+    pub(crate) fn render_into(&self, variables: TemplateVariables<'_>, to: &mut String) {
+        let mut offset = 0;
+
+        for Component { size, data } in self.components.iter().copied() {
+            let size = size as usize;
+            match data {
+                ComponentData::Variable(var) => {
+                    Self::expand_variable(var, &variables, to);
+                }
+                ComponentData::Path => {
+                    to.push_str(&self.template[offset..offset + size]);
+                }
+            }
+
+            offset += size;
+        }
+    }
+}
+
+impl DumpPath {
+    fn parse_variable(var: &str) -> Option<Variable> {
+        use Variable as V;
+
+        Some(match var {
+            "time" => V::Time,
+            "class" => V::Class,
+            _ => return None,
+        })
+    }
+
+    fn push_path(of_size: &mut usize, to: &mut Vec<Component>) {
+        if *of_size != 0 {
+            to.push(Component {
+                size: *of_size as u16,
+                data: ComponentData::Path,
+            });
+            *of_size = 0;
+        }
+    }
+
+    /// Parse template.
+    fn parse(s: impl Into<String>) -> DumpPath {
+        let template = s.into();
+        let mut components = vec![];
+
+        let mut plain_size = 0;
+        let mut chunk = template.as_str();
+
+        loop {
+            // original = "xxx {yyy} zzz"
+            // before = "xxx "
+            // after = "yyy} zzz"
+            let Some((before, after)) = chunk.split_once('{') else {
+                // no more template variables.
+                plain_size += chunk.len();
+                break;
+            };
+            plain_size += before.len();
+
+            // raw_variable = "yyy"
+            // after = " zzz"
+            let Some((raw_variable, after)) = after.split_once('}') else {
+                // 1 = {, which is not in "before".
+                plain_size += 1;
+                chunk = after;
+                continue;
+            };
+            let Some(variable) = Self::parse_variable(raw_variable) else {
+                // "{<variable>}"
+                plain_size += 2 + raw_variable.len();
+                chunk = after;
+                continue;
+            };
+
+            Self::push_path(&mut plain_size, &mut components);
+            components.push(Component {
+                // "{<variable>}"
+                size: raw_variable.len() as u16 + 2,
+                data: ComponentData::Variable(variable),
+            });
+            chunk = after;
+        }
+        Self::push_path(&mut plain_size, &mut components);
+
+        DumpPath {
+            template,
+            components,
+        }
+    }
+}
+
+impl fmt::Display for DumpPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.template)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+enum ComponentData {
+    /// Simple path, no templating.
+    Path,
+
+    /// Template variable.
+    Variable(Variable),
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+enum Variable {
+    /// Dump class.
+    Class,
+
+    /// Time of the dump.
+    Time,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+struct Component {
+    /// How much this component occupies space in template, in bytes. Each
+    /// component contains not the entire span like `(Offset, Size)`, but
+    /// only size, since components are arranged according to occurence in
+    /// template string, thus offset of each component can be calculated
+    /// during rendering, for free, since components are rendered
+    /// sequentially in any case.
+    size: u16,
+    data: ComponentData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_renders_successfully() {
+        #[track_caller]
+        fn case(template: &str, vars: TemplateVariables<'_>, expected: &str) {
+            let path = DumpPath::parse(template);
+            let mut actual = String::new();
+            path.render_into(vars, &mut actual);
+
+            assert_eq!(actual, expected);
+        }
+
+        // Simple class substitution
+        case(
+            "/tmp/{class}.dump",
+            TemplateVariables {
+                class: "class",
+                ts: 0,
+            },
+            "/tmp/class.dump",
+        );
+
+        // Class and time.
+        case(
+            "/tmp/dump-{class}-{time}.dump",
+            TemplateVariables {
+                class: "class",
+                ts: 1337100,
+            },
+            "/tmp/dump-system.network-1337100.dump",
+        );
+    }
+
+    #[test]
+    fn it_parses_correctly() {
+        #[track_caller]
+        fn case<I>(template: &'static str, expected: I)
+        where
+            I: IntoIterator<Item = (u16, ComponentData)>,
+        {
+            let expected: Vec<Component> = expected
+                .into_iter()
+                .map(|(size, data)| Component { size, data })
+                .collect();
+            let actual = DumpPath::parse(template);
+
+            assert_eq!(expected, actual.components);
+        }
+
+        use ComponentData as D;
+
+        // Path without template variables.
+        case("/tmp/dump.dump", [(14, D::Path)]);
+
+        // Dump with class.
+        case(
+            "/tmp/{class}.dump",
+            [
+                (5, D::Path),
+                (7, D::Variable(Variable::Class)),
+                (5, D::Path),
+            ],
+        );
+
+        // {time} precedes {class}.
+        case(
+            "/tmp/{class}{time}.dump",
+            [
+                (5, D::Path),
+                (7, D::Variable(Variable::Class)),
+                (6, D::Variable(Variable::Time)),
+                (5, D::Path),
+            ],
+        );
+
+        // Invalid template variables are treated just like path.
+        case("/tmp/{lol}{kek}.dump", [(20, D::Path)]);
+
+        // Valid template variable precedes invalid.
+        case(
+            "/tmp/{lol}{time}.dump",
+            [
+                (10, D::Path),
+                (6, D::Variable(Variable::Time)),
+                (5, D::Path),
+            ],
+        );
+    }
+}

--- a/elfo-dumper/src/config/dump_path.rs
+++ b/elfo-dumper/src/config/dump_path.rs
@@ -190,7 +190,7 @@ enum Variable {
 
     /// Time of the dump.
     Time {
-        /// strptime string format.
+        /// strftime string format.
         format: cstr::Utf8CString,
     },
 }
@@ -241,7 +241,7 @@ fn strftime(ts: i64, format: &cstr::Utf8CString, dest: &mut String) -> bool {
     unsafe {
         // 1. mem::transmute wouldn't compile if u8 and libc::c_char differ in size
         // (there are strange circumstances).
-        // 2. `libc::c_char` to i8 is i8 -> u8 conversion, thus converting
+        // 2. `libc::c_char` to u8 is i8 -> u8 conversion, thus converting
         // same-sized arrays through transmute is safe (btw transmute checks that
         // condition in compile time)
         let u8_array = std::mem::transmute::<

--- a/elfo-dumper/src/file_registry.rs
+++ b/elfo-dumper/src/file_registry.rs
@@ -62,8 +62,9 @@ impl FileRegistry {
 
         // NOTE: a bit racy part here, two threads observe
         // file status (open or not open) in random order, but it doesn't
-        // matter here, since after first thread opens the file - it's guaranteed by underlying mutex that
-        // other threads will see it as open, thus opening will pe performed only once.
+        // matter here, since after first thread opens the file - it's guaranteed by
+        // underlying mutex that other threads will see it as open, thus opening
+        // will pe performed only once.
         Self::open_inner(path, false, &mut fh).await?;
         Ok(fh)
     }

--- a/elfo-dumper/src/file_registry.rs
+++ b/elfo-dumper/src/file_registry.rs
@@ -37,7 +37,7 @@ impl FileRegistry {
     pub(crate) async fn open(&self, path: &str, force: bool) -> Result<()> {
         let mut file = {
             let mut files = self.files.lock();
-            Self::insert_handle(path, &mut *files)
+            Self::insert_handle(path, &mut files)
         };
 
         Self::open_inner(path, force, &mut file).await?;
@@ -57,7 +57,7 @@ impl FileRegistry {
                 files.remove(old_path);
             }
 
-            Self::insert_handle(path, &mut *files)
+            Self::insert_handle(path, &mut files)
         };
 
         // NOTE: a bit racy part here, two threads observe

--- a/elfo-dumper/src/file_registry.rs
+++ b/elfo-dumper/src/file_registry.rs
@@ -17,30 +17,55 @@ pub(crate) struct FileRegistry {
 }
 
 impl FileRegistry {
-    pub(crate) async fn open(&self, path: &str, force: bool) -> Result<()> {
-        let mut file = {
-            let mut files = self.files.lock();
+    fn insert_handle(path: &str, files: &mut FxHashMap<String, FileHandle>) -> FileHandle {
+        let contained = files.contains_key(path);
+        if !contained {
+            files.insert(path.to_string(), FileHandle::default());
+        }
 
-            if !files.contains_key(path) {
-                files.insert(path.to_string(), FileHandle::default());
-            }
+        files.get(path).unwrap().clone()
+    }
 
-            files.get(path).unwrap().clone()
-        };
-
-        if file.open(path, force).await? {
+    async fn open_inner(path: &str, force: bool, fh: &mut FileHandle) -> Result<()> {
+        if fh.open(path, force).await? {
             debug!(%path, "file opened");
         }
 
         Ok(())
     }
 
-    pub(crate) async fn acquire(&self, path: &str) -> FileHandle {
-        self.files
-            .lock()
-            .get(path)
-            .expect("file must be open already")
-            .clone()
+    pub(crate) async fn open(&self, path: &str, force: bool) -> Result<()> {
+        let mut file = {
+            let mut files = self.files.lock();
+            Self::insert_handle(path, &mut *files)
+        };
+
+        Self::open_inner(path, force, &mut file).await?;
+        Ok(())
+    }
+
+    /// Open file for writing dump in it, closing previous one if
+    /// paths differ.
+    pub(crate) async fn acquire_for_write(&self, old_path: &str, path: &str) -> Result<FileHandle> {
+        let mut fh = {
+            let mut files = self.files.lock();
+            if old_path != path {
+                // Close previous file.
+                // NOTE: this won't cause any bugs if two dumpers write to
+                // the same file, since `FileHandle` is reference counted, thus
+                // removing it from map only decreases refcounter by one.
+                files.remove(old_path);
+            }
+
+            Self::insert_handle(path, &mut *files)
+        };
+
+        // NOTE: a bit racy part here, two threads observe
+        // file status (open or not open) in random order, but it doesn't
+        // matter here, since after first thread opens the file - it's guaranteed by underlying mutex that
+        // other threads will see it as open, thus opening will pe performed only once.
+        Self::open_inner(path, false, &mut fh).await?;
+        Ok(fh)
     }
 
     pub(crate) async fn sync(&self, path: &str) -> Result<()> {


### PR DESCRIPTION
Implements more flexible templating for storing dumps. Questions needed to be resolved in order to undraft:

- [x] Time precision

The `{time}` itself has no information about precision (to hours? to minutes? to seconds?) and format (ISO? unix time?), we either need to choose format and precision, or allow customization, like  `strftime`, but simpler: `{time:dd-mm-YYYY}` with some default when format is omitted.
IMO latter is better, it gives more flexibility in granularity.

- [x] Time source

We could use last dump message time or time when writing dump to the disk. IMO latter is nice approximation, since for the rotation purposes we usually need to clean-up space, not specific time interval and using that approximation wouldn't be problematic - time of writing the dump is never less than last dump message time, so, the worst-case scenario is keeping for some time expired files in FS. Or the hell scenario is broken system clock, which is problematic in any chosen way.