### PR TITLE
Remove lifetime from `Proxy::request()` future

### DIFF
--- a/elfo-core/src/actor_status.rs
+++ b/elfo-core/src/actor_status.rs
@@ -1,5 +1,7 @@
-use std::sync::atomic::{self, AtomicU8};
-use std::{fmt, mem};
+use std::{
+    fmt, mem,
+    sync::atomic::{self, AtomicU8},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -142,8 +144,9 @@ impl AtomicActorStatusKind {
         let result = self.0.load(ordering);
 
         // SAFETY: `ActorStatusKind` has `#[repr(u8)]` annotation. The only
-        // place where value may be changed is `Self::store`, which consumes `ActorStatusKind`, thus,
-        // guarantees that possibly invalid value cannot be stored
+        // place where value may be changed is `Self::store`, which consumes
+        // `ActorStatusKind`, thus, guarantees that possibly invalid value
+        // cannot be stored
         unsafe { mem::transmute::<u8, ActorStatusKind>(result) }
     }
 }

--- a/elfo-core/src/address_book.rs
+++ b/elfo-core/src/address_book.rs
@@ -109,7 +109,7 @@ pub(crate) struct VacantEntry<'g> {
     group_no: GroupNo,
 }
 
-impl<'g> VacantEntry<'g> {
+impl VacantEntry<'_> {
     pub(crate) fn insert(self, object: Object) {
         self.entry.insert(object)
     }

--- a/elfo-core/src/message/any.rs
+++ b/elfo-core/src/message/any.rs
@@ -347,7 +347,7 @@ struct MessageTag<'a> {
     name: &'a str,
 }
 
-impl<'de, 'tag> de::DeserializeSeed<'de> for MessageTag<'tag> {
+impl<'de> de::DeserializeSeed<'de> for MessageTag<'_> {
     type Value = AnyMessage;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>

--- a/elfo-core/src/topology.rs
+++ b/elfo-core/src/topology.rs
@@ -194,7 +194,7 @@ pub struct Local<'t> {
     demux: RefCell<Demux>,
 }
 
-impl<'t> Local<'t> {
+impl Local<'_> {
     #[doc(hidden)]
     pub fn addr(&self) -> Addr {
         self.entry.addr()
@@ -497,7 +497,7 @@ cfg_network!({
         nodes: Option<Nodes>,
     }
 
-    impl<'a> RegisterRemoteGroupGuard<'a> {
+    impl RegisterRemoteGroupGuard<'_> {
         pub fn handle_addr(&self) -> Addr {
             self.handle_addr
         }

--- a/elfo-dumper/src/dump_storage.rs
+++ b/elfo-dumper/src/dump_storage.rs
@@ -328,7 +328,7 @@ impl<'a> Drain<'a> {
     }
 }
 
-impl<'a> Iterator for Drain<'a> {
+impl Iterator for Drain<'_> {
     type Item = Dump;
 
     fn next(&mut self) -> Option<Dump> {

--- a/elfo-dumper/src/serializer.rs
+++ b/elfo-dumper/src/serializer.rs
@@ -181,7 +181,7 @@ struct CompactDump<'a> {
     message: Option<Cow<'a, str>>,
 }
 
-impl<'a> serde::Serialize for CompactDump<'a> {
+impl serde::Serialize for CompactDump<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let field_count = 12
             + !self.dump.meta.key.is_empty() as usize // "k"

--- a/elfo-logger/src/line_buffer.rs
+++ b/elfo-logger/src/line_buffer.rs
@@ -20,7 +20,7 @@ struct Repr<'a> {
 #[derive(Debug)]
 pub(crate) struct TruncatingWrite<'a>(Repr<'a>);
 
-impl<'a> Line for TruncatingWrite<'a> {
+impl Line for TruncatingWrite<'_> {
     fn try_commit(mut self) -> bool {
         let add_truncated_marker = self.probe_size_limit();
 
@@ -51,7 +51,7 @@ impl<'a> Line for TruncatingWrite<'a> {
     }
 }
 
-impl<'a> TruncatingWrite<'a> {
+impl TruncatingWrite<'_> {
     fn meta_len(&self) -> usize {
         self.0.buf.buffer.len() - self.0.pre_start_buffer_size
     }
@@ -61,7 +61,7 @@ impl<'a> TruncatingWrite<'a> {
     }
 }
 
-impl<'a> TruncatingWrite<'a> {
+impl TruncatingWrite<'_> {
     fn probe_size_limit(&mut self) -> bool {
         let len = self.len();
         let mut need_to_erase = if len > self.0.buf.max_line_size {
@@ -96,7 +96,7 @@ impl<'a> TruncatingWrite<'a> {
     }
 }
 
-impl<'a> Drop for TruncatingWrite<'a> {
+impl Drop for TruncatingWrite<'_> {
     fn drop(&mut self) {
         self.0.buf.buffer.truncate(self.0.pre_start_buffer_size);
     }
@@ -107,7 +107,7 @@ impl<'a> Drop for TruncatingWrite<'a> {
 #[derive(Debug)]
 pub(crate) struct DirectWrite<'a>(Repr<'a>);
 
-impl<'a> DirectWrite<'a> {
+impl DirectWrite<'_> {
     fn len(&self) -> usize {
         self.0.buf.buffer.len() - self.0.pre_start_buffer_size
     }
@@ -144,7 +144,7 @@ impl Line for DirectWrite<'_> {
     }
 }
 
-impl<'a> Drop for DirectWrite<'a> {
+impl Drop for DirectWrite<'_> {
     fn drop(&mut self) {
         self.0.buf.buffer.truncate(self.0.pre_start_buffer_size);
     }

--- a/elfo-test/src/proxy.rs
+++ b/elfo-test/src/proxy.rs
@@ -98,11 +98,12 @@ impl Proxy {
 
     /// See [`Context::request()`] for details.
     #[track_caller]
-    pub fn request<R: Request>(&self, request: R) -> impl Future<Output = R::Response> + '_ {
+    pub fn request<R: Request>(&self, request: R) -> impl Future<Output = R::Response> {
         let location = Location::caller();
+        let context = self.context.pruned();
         self.scope.clone().within(async move {
             let name = request.name();
-            match self.context.request(request).resolve().await {
+            match context.request(request).resolve().await {
                 Ok(response) => response,
                 Err(err) => panic!("cannot send {} ({}) at {}", name, err, location),
             }
@@ -115,11 +116,12 @@ impl Proxy {
         &self,
         recipient: Addr,
         request: R,
-    ) -> impl Future<Output = R::Response> + '_ {
+    ) -> impl Future<Output = R::Response> {
         let location = Location::caller();
+        let context = self.context.pruned();
         self.scope.clone().within(async move {
             let name = request.name();
-            match self.context.request_to(recipient, request).resolve().await {
+            match context.request_to(recipient, request).resolve().await {
                 Ok(response) => response,
                 Err(err) => panic!("cannot send {} ({}) at {}", name, err, location),
             }

--- a/elfo/tests/common.rs
+++ b/elfo/tests/common.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)] // TODO: combine tests into "it/*"
+#![allow(missing_docs)]
 
 // For tests without `elfo::test::proxy`.
 pub(crate) fn setup_logger() {

--- a/elfo/tests/config_validation.rs
+++ b/elfo/tests/config_validation.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use elfo::{

--- a/elfo/tests/gentle_outcome.rs
+++ b/elfo/tests/gentle_outcome.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::panic::AssertUnwindSafe;

--- a/elfo/tests/mailbox_capacity.rs
+++ b/elfo/tests/mailbox_capacity.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::time::Duration;

--- a/elfo/tests/message_macro.rs
+++ b/elfo/tests/message_macro.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use serde::Serialize;
 use static_assertions::*;
 

--- a/elfo/tests/msg_macro.rs
+++ b/elfo/tests/msg_macro.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use elfo::{config::AnyConfig, prelude::*};

--- a/elfo/tests/protocol_evolution.rs
+++ b/elfo/tests/protocol_evolution.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "network")]
 
 use std::collections::HashMap;

--- a/elfo/tests/remote_messaging.rs
+++ b/elfo/tests/remote_messaging.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "network")]
 #![cfg(feature = "turmoil06")]
 

--- a/elfo/tests/request_routing.rs
+++ b/elfo/tests/request_routing.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::time::Duration;

--- a/elfo/tests/restarting.rs
+++ b/elfo/tests/restarting.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 #![allow(clippy::never_loop)]
 

--- a/elfo/tests/source_delay.rs
+++ b/elfo/tests/source_delay.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::{collections::HashMap, time::Duration};

--- a/elfo/tests/source_interval.rs
+++ b/elfo/tests/source_interval.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::time::Duration;

--- a/elfo/tests/source_signal.rs
+++ b/elfo/tests/source_signal.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 #![cfg_attr(windows, allow(unused_imports))] // TODO: test on windows
 #![allow(clippy::await_holding_lock)]

--- a/elfo/tests/source_stream.rs
+++ b/elfo/tests/source_stream.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::{collections::HashMap, sync::Arc, time::Duration};

--- a/elfo/tests/start_info.rs
+++ b/elfo/tests/start_info.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::{num::NonZeroU64, time::Duration};

--- a/elfo/tests/subscription_to_statuses.rs
+++ b/elfo/tests/subscription_to_statuses.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use std::time::Duration;

--- a/elfo/tests/termination.rs
+++ b/elfo/tests/termination.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 #![allow(clippy::never_loop)]
 

--- a/elfo/tests/ui.rs
+++ b/elfo/tests/ui.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/elfo/tests/update_config.rs
+++ b/elfo/tests/update_config.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 
 use serde::Deserialize;


### PR DESCRIPTION
- Remove lifetime from `Proxy::request()`, which helps in testing complex request scenarios
- Fix CI