### PR TITLE
allow construction of arbitrary `ActorStatusKind` in tests

### DIFF
--- a/elfo-core/src/actor_status.rs
+++ b/elfo-core/src/actor_status.rs
@@ -17,22 +17,20 @@ pub struct ActorStatus {
 
 impl ActorStatus {
     pub const ALARMING: ActorStatus = ActorStatus::new(ActorStatusKind::Alarming);
-    pub(crate) const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
-    pub const INITIALIZING: ActorStatus = ActorStatus::new(ActorStatusKind::Initializing);
-    pub const NORMAL: ActorStatus = ActorStatus::new(ActorStatusKind::Normal);
-    pub(crate) const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
-    pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
 
     #[cfg(not(feature = "test-util"))]
-    const fn new(kind: ActorStatusKind) -> Self {
-        Self {
-            kind,
-            details: None,
-        }
-    }
-
+    pub(crate) const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
     #[cfg(feature = "test-util")]
-    pub const fn new(kind: ActorStatusKind) -> Self {
+    pub const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
+    pub const INITIALIZING: ActorStatus = ActorStatus::new(ActorStatusKind::Initializing);
+    pub const NORMAL: ActorStatus = ActorStatus::new(ActorStatusKind::Normal);
+    #[cfg(not(feature = "test-util"))]
+    pub(crate) const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
+    #[cfg(feature = "test-util")]
+    pub const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
+    pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
+
+    const fn new(kind: ActorStatusKind) -> Self {
         Self {
             kind,
             details: None,

--- a/elfo-core/src/actor_status.rs
+++ b/elfo-core/src/actor_status.rs
@@ -23,7 +23,16 @@ impl ActorStatus {
     pub(crate) const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
     pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
 
+    #[cfg(not(feature = "test-util"))]
     const fn new(kind: ActorStatusKind) -> Self {
+        Self {
+            kind,
+            details: None,
+        }
+    }
+
+    #[cfg(feature = "test-util")]
+    pub const fn new(kind: ActorStatusKind) -> Self {
         Self {
             kind,
             details: None,

--- a/elfo-core/src/actor_status.rs
+++ b/elfo-core/src/actor_status.rs
@@ -16,20 +16,6 @@ pub struct ActorStatus {
 }
 
 impl ActorStatus {
-    pub const ALARMING: ActorStatus = ActorStatus::new(ActorStatusKind::Alarming);
-
-    #[cfg(not(feature = "test-util"))]
-    pub(crate) const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
-    #[cfg(feature = "test-util")]
-    pub const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
-    pub const INITIALIZING: ActorStatus = ActorStatus::new(ActorStatusKind::Initializing);
-    pub const NORMAL: ActorStatus = ActorStatus::new(ActorStatusKind::Normal);
-    #[cfg(not(feature = "test-util"))]
-    pub(crate) const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
-    #[cfg(feature = "test-util")]
-    pub const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
-    pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
-
     const fn new(kind: ActorStatusKind) -> Self {
         Self {
             kind,
@@ -54,6 +40,26 @@ impl ActorStatus {
     pub fn details(&self) -> Option<&str> {
         self.details.as_deref()
     }
+}
+
+#[cfg(not(feature = "test-util"))]
+impl ActorStatus {
+    pub const ALARMING: ActorStatus = ActorStatus::new(ActorStatusKind::Alarming);
+    pub(crate) const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
+    pub const INITIALIZING: ActorStatus = ActorStatus::new(ActorStatusKind::Initializing);
+    pub const NORMAL: ActorStatus = ActorStatus::new(ActorStatusKind::Normal);
+    pub(crate) const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
+    pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
+}
+
+#[cfg(feature = "test-util")]
+impl ActorStatus {
+    pub const ALARMING: ActorStatus = ActorStatus::new(ActorStatusKind::Alarming);
+    pub const FAILED: ActorStatus = ActorStatus::new(ActorStatusKind::Failed);
+    pub const INITIALIZING: ActorStatus = ActorStatus::new(ActorStatusKind::Initializing);
+    pub const NORMAL: ActorStatus = ActorStatus::new(ActorStatusKind::Normal);
+    pub const TERMINATED: ActorStatus = ActorStatus::new(ActorStatusKind::Terminated);
+    pub const TERMINATING: ActorStatus = ActorStatus::new(ActorStatusKind::Terminating);
 }
 
 impl fmt::Display for ActorStatus {


### PR DESCRIPTION
Not all `ActorStatusKind` variants are public, however it is sometimes desirable to construct arbitrary variants in testing environment