### PR TITLE
Add test-util constructor for `ReloadConfigsRejected`

### DIFF
--- a/elfo-configurer/Cargo.toml
+++ b/elfo-configurer/Cargo.toml
@@ -27,3 +27,6 @@ fxhash = "0.2.1"
 
 [dev-dependencies]
 serde_json = "1.0.94"
+
+[features]
+test-util = []

--- a/elfo-configurer/src/protocol.rs
+++ b/elfo-configurer/src/protocol.rs
@@ -26,10 +26,10 @@ pub struct ReloadConfigsRejected {
 }
 
 impl ReloadConfigsRejected {
-    /// Create new empty reject.
+    /// Creates new empty reject.
     #[cfg(feature = "test-util")]
-    pub fn new() -> Self {
-        ReloadConfigsRejected { errors: Vec::new() }
+    pub fn empty(errors: Vec<ReloadConfigsError>) -> Self {
+        Self { errors }
     }
 }
 
@@ -41,4 +41,12 @@ pub struct ReloadConfigsError {
     pub group: String,
     /// The reason why the config is rejected.
     pub reason: String,
+}
+
+impl ReloadConfigsError {
+    /// Creates new error.
+    #[cfg(feature = "test-util")]
+    pub fn new(group: String, reason: String) -> Self {
+        Self { group, reason }
+    }
 }

--- a/elfo-configurer/src/protocol.rs
+++ b/elfo-configurer/src/protocol.rs
@@ -26,6 +26,7 @@ pub struct ReloadConfigsRejected {
 }
 
 impl ReloadConfigsRejected {
+    /// Create new empty reject.
     #[cfg(feature = "test-util")]
     pub fn new() -> Self {
         ReloadConfigsRejected { errors: Vec::new() }

--- a/elfo-configurer/src/protocol.rs
+++ b/elfo-configurer/src/protocol.rs
@@ -26,9 +26,9 @@ pub struct ReloadConfigsRejected {
 }
 
 impl ReloadConfigsRejected {
-    /// Creates new empty reject.
+    /// Creates a new reject.
     #[cfg(feature = "test-util")]
-    pub fn empty(errors: Vec<ReloadConfigsError>) -> Self {
+    pub fn new(errors: Vec<ReloadConfigsError>) -> Self {
         Self { errors }
     }
 }
@@ -44,7 +44,7 @@ pub struct ReloadConfigsError {
 }
 
 impl ReloadConfigsError {
-    /// Creates new error.
+    /// Creates a new error.
     #[cfg(feature = "test-util")]
     pub fn new(group: String, reason: String) -> Self {
         Self { group, reason }

--- a/elfo-configurer/src/protocol.rs
+++ b/elfo-configurer/src/protocol.rs
@@ -25,6 +25,13 @@ pub struct ReloadConfigsRejected {
     pub errors: Vec<ReloadConfigsError>,
 }
 
+impl ReloadConfigsRejected {
+    #[cfg(feature = "test-util")]
+    pub fn new() -> Self {
+        ReloadConfigsRejected { errors: Vec::new() }
+    }
+}
+
 /// Contains a reason why some actor rejects the config.
 #[message(part)]
 #[non_exhaustive]

--- a/elfo/Cargo.toml
+++ b/elfo/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 full = ["elfo-configurer", "elfo-logger", "elfo-dumper", "elfo-telemeter", "elfo-pinger"]
-test-util = ["elfo-test", "elfo-core/test-util"]
+test-util = ["elfo-test", "elfo-core/test-util", "elfo-configurer/test-util"]
 network = ["elfo-network"]
 unstable = ["elfo-core/unstable", "elfo-telemeter/unstable", "elfo-test/unstable" ]
 unstable-stuck-detection = ["elfo-core/unstable-stuck-detection"]


### PR DESCRIPTION
When testing actors, it may come in handy to respond with `ReloadConfigsRejected`. However, due to the structure being `non_exhaustive`, it's impossible to construct outside of `elfo` itself. This MR adds such a constructor under the `test-util` feature.