### PR TITLE
feat: implement `AnyMessage::downcast_mut()`

### DIFF
--- a/elfo-core/src/message.rs
+++ b/elfo-core/src/message.rs
@@ -92,6 +92,15 @@ pub trait Message:
         any.as_real_ref()
     }
 
+    /// # Safety
+    ///
+    /// The caller must ensure that `any` holds this message type.
+    #[doc(hidden)]
+    #[inline(always)]
+    unsafe fn _from_any_mut(any: &mut AnyMessage) -> &mut Self {
+        any.as_real_mut()
+    }
+
     #[doc(hidden)]
     #[inline(always)]
     fn _erase(&self) -> dumping::ErasedMessage {


### PR DESCRIPTION
Complements existing `AnyMessage::downcast()` and `AnyMessage::downcast_ref()`, allowing to modify stored `AnyMessage`s without reallocation.