### PR TITLE
fix(network): use only mounted local groups

### DIFF
--- a/elfo-core/src/message/any.rs
+++ b/elfo-core/src/message/any.rs
@@ -125,7 +125,8 @@ impl AnyMessage {
         M::_from_any_ref(self)
     }
 
-    /// Tries to downcast the message to a mutable reference to the concrete type.
+    /// Tries to downcast the message to a mutable reference to the concrete
+    /// type.
     ///
     /// Note: it returns `Some(&mut self)` if `M` is [`AnyMessage`].
     #[inline]


### PR DESCRIPTION
`elfo-network` will panic on destination node if message was routed to actor group which is not mounted.

## Steps to reproduce

```shell
$ git diff examples
diff --git a/examples/network/bob.rs b/examples/network/bob.rs
index 73a1989..5e00fe7 100644
--- a/examples/network/bob.rs
+++ b/examples/network/bob.rs
@@ -39,12 +39,13 @@ pub(crate) fn topology() -> elfo::Topology {

     // Local user groups.
     let consumers = topology.local("consumers");
+    drop(consumers);

     loggers.mount(logger);
     telemeters.mount(telemeter);
     dumpers.mount(elfo::batteries::dumper::new());
     network.mount(elfo::batteries::network::new(&topology));
-    consumers.mount(consumer());
+    //consumers.mount(consumer());

     let config_path = "examples/network/bob.toml";
```

Then
```shell
$ cargo run --bin network --features network -- alice
$ cargo run --bin network --features network -- bob
```

The bob will panic:
```
thread 'tokio-runtime-worker' panicked at elfo-network/src/worker/mod.rs:645:14:
invalid local group addr
```

## Fix

We'll simply skip groups which aren't mounted in `locals` iterator, thus `LocalActorGroup` now carries information whether it's mounted or not.