### PR TITLE
chore: fix dependency specifications

### DIFF
--- a/elfo-telemeter/Cargo.toml
+++ b/elfo-telemeter/Cargo.toml
@@ -26,7 +26,7 @@ elfo-core = { version = "0.2.0-alpha.19", path = "../elfo-core", features = ["un
 
 stability.workspace = true
 metrics.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["net"] }
 hyper = { version = "1.0.1", features = ["server", "http1"] }
 hyper-util = { version = "0.1.3", features = ["tokio"] }
 http-body-util = "0.1"

--- a/elfo/Cargo.toml
+++ b/elfo/Cargo.toml
@@ -16,12 +16,12 @@ workspace = true
 
 [features]
 full = ["elfo-configurer", "elfo-logger", "elfo-dumper", "elfo-telemeter", "elfo-pinger"]
-test-util = ["elfo-test", "elfo-core/test-util", "elfo-configurer/test-util"]
+test-util = ["elfo-test", "elfo-core/test-util", "elfo-configurer?/test-util"]
 network = ["elfo-network"]
-unstable = ["elfo-core/unstable", "elfo-telemeter/unstable", "elfo-test/unstable" ]
+unstable = ["elfo-core/unstable", "elfo-telemeter?/unstable", "elfo-test?/unstable" ]
 unstable-stuck-detection = ["elfo-core/unstable-stuck-detection"]
-tracing-log = ["elfo-logger/tracing-log"]
-turmoil06 = ["elfo-network/turmoil06"]
+tracing-log = ["elfo-logger?/tracing-log"]
+turmoil06 = ["elfo-network?/turmoil06"]
 
 [dependencies]
 elfo-core = { version = "=0.2.0-alpha.19", path = "../elfo-core" }


### PR DESCRIPTION
1. Change feature propagation from `/` to `?/`, so enabling e.g. `unstable` on `elfo` doesn't unconditionally enable other components like `elfo-telemeter`.

2. Specifies that `elfo-telemeter` depends on `tokio/net`.