### PR TITLE
chore(ci/msrv): check deps' minimal versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
     - run: rustup show active-toolchain -v
     - run: cargo build --all-targets --all-features
 
@@ -28,14 +29,15 @@ jobs:
     env:
       RUSTFLAGS: "" # remove -Dwarnings
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@cargo-minimal-versions
-      - run: rustup toolchain install ${{ env.MSRV }} --profile minimal
-      - run: rustup override set ${{ env.MSRV }}
-      - run: rustup show active-toolchain -v
-      - run: cargo minimal-versions check --all --direct
-      - run: cargo minimal-versions check --all --direct --all-features
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@cargo-hack
+    - uses: taiki-e/install-action@cargo-minimal-versions
+    - run: rustup toolchain install ${{ env.MSRV }} --profile minimal
+    - run: rustup override set ${{ env.MSRV }}
+    - run: rustup show active-toolchain -v
+    - run: cargo minimal-versions check --all --direct
+    - run: cargo minimal-versions check --all --direct --all-features
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -50,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
     - run: rustup show active-toolchain -v
     - run: rustup component add clippy
     - run: cargo clippy --version
@@ -60,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-llvm-cov
     - run: rustup show active-toolchain -v
     - run: cargo llvm-cov test --no-report
@@ -76,12 +80,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: rustup toolchain install nightly --component miri
-      - run: rustup override set nightly
-      - run: rustup show active-toolchain -v
-      - run: cargo miri setup
-      - run: cargo miri test -p elfo-core --all-features -- _miri
+    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
+    - run: rustup toolchain install nightly --component miri
+    - run: rustup override set nightly
+    - run: rustup show active-toolchain -v
+    - run: cargo miri setup
+    - run: cargo miri test -p elfo-core --all-features -- _miri
 
   docs:
     needs: build
@@ -90,6 +95,7 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings --cfg docsrs
     steps:
     - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
     - run: rustup toolchain install nightly
     - run: rustup override set nightly
     - run: rustup show active-toolchain -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,13 @@ jobs:
       RUSTFLAGS: "" # remove -Dwarnings
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
       - run: rustup toolchain install ${{ env.MSRV }} --profile minimal
       - run: rustup override set ${{ env.MSRV }}
       - run: rustup show active-toolchain -v
-      - run: cargo build
-      - run: cargo build --all-features
+      - run: cargo minimal-versions check --all --direct
+      - run: cargo minimal-versions check --all --direct --all-features
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,20 @@ tokio = "1.37"
 stability = "0.2.0"
 metrics = "0.17.1"
 dashmap = "6.0.1"
-toml = "0.8.14"
+toml = "0.9"
 bytesize = { version = "2", features = ["serde"] }
 proptest = "1.6"
 criterion = "0.5.1"
 eyre = "0.6.8"
 slotmap = { version = "1.0.7", features = ["serde"] }
 pin-project = "1.0.8"
+futures = "0.3.21"
+libc = "0.2.169"
+thread_local = "1.1.8"
+tracing = "0.1.27"
+tracing-subscriber = "0.3.8"
+parking_lot = "0.12.1"
+serde = { version = "1.0.166", features = ["derive"] }
 
 [workspace.dependencies.derive_more]
 version = "2"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,7 +18,7 @@ metrics.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 derive_more.workspace = true
 criterion.workspace = true
-futures = "0.3"
+futures.workspace = true
 mimalloc = { version = "0.1.39", default-features = false }
 jemallocator = "0.5.4"
 tcmalloc = { version = "0.3.0", features = ["bundled"] }

--- a/elfo-configurer/Cargo.toml
+++ b/elfo-configurer/Cargo.toml
@@ -19,10 +19,10 @@ elfo-core = { version = "0.2.0-alpha.20", path = "../elfo-core", features = ["un
 
 toml.workspace = true
 tokio = { workspace = true, features = ["fs"] }
-serde = { version = "1.0.120", features = ["derive", "rc"] }
+futures.workspace = true
+serde = { workspace = true, features = ["rc"] }
+tracing.workspace = true
 serde-value = "0.7.0"
-futures = "0.3.12"
-tracing = "0.1.25"
 fxhash = "0.2.1"
 
 [dev-dependencies]

--- a/elfo-core/Cargo.toml
+++ b/elfo-core/Cargo.toml
@@ -29,15 +29,16 @@ metrics.workspace = true
 dashmap.workspace = true
 derive_more.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "time", "signal", "macros"] }
+futures.workspace = true
+thread_local = { workspace = true, optional = true }
+parking_lot.workspace = true
+# TODO: avoid the `rc` feature here?
+serde = { workspace = true, features = ["rc"] }
+tracing.workspace = true
 idr-ebr = "0.3.0"
 futures-intrusive = "0.5"
 cordyceps = "0.3.2"
-parking_lot = "0.12"
 smallbox = "0.8.0"
-# TODO: avoid the `rc` feature here?
-serde = { version = "1.0.120", features = ["derive", "rc"] }
-tracing = "0.1.25"
-futures = "0.3.12"
 static_assertions = "1.1.0"
 fxhash = "0.2.1"
 linkme = "0.3"
@@ -48,10 +49,8 @@ arc-swap = "1.2.0"
 erased-serde = "0.4.0"
 pin-project.workspace = true
 sealed = "0.6"
-once_cell = { version = "1.8.0", features = ["parking_lot"] }
 serde_json = { version = "1.0.64", features = ["raw_value"] }
 regex = "1.6.0"
-thread_local = { version = "1.1.3", optional = true }
 unicycle = "0.10.2"
 rmp-serde = { version = "1.1.0", optional = true }
 humantime-serde = "1"

--- a/elfo-core/src/context.rs
+++ b/elfo-core/src/context.rs
@@ -1,8 +1,13 @@
-use std::{future::poll_fn, marker::PhantomData, pin::Pin, sync::Arc, task::Poll};
+use std::{
+    future::poll_fn,
+    marker::PhantomData,
+    pin::Pin,
+    sync::{Arc, LazyLock},
+    task::Poll,
+};
 
 use futures::{pin_mut, Stream};
 use idr_ebr::EbrGuard;
-use once_cell::sync::Lazy;
 use tracing::{info, trace};
 
 use elfo_utils::unlikely;
@@ -34,7 +39,7 @@ use self::stats::Stats;
 
 mod stats;
 
-static DUMPER: Lazy<Dumper> = Lazy::new(|| Dumper::new(INTERNAL_CLASS));
+static DUMPER: LazyLock<Dumper> = LazyLock::new(|| Dumper::new(INTERNAL_CLASS));
 
 /// An actor execution context.
 pub struct Context<C = (), K = Singleton> {

--- a/elfo-core/src/dumping/recorder.rs
+++ b/elfo-core/src/dumping/recorder.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
-use once_cell::sync::OnceCell;
+use std::sync::{Arc, OnceLock};
 
 use super::Dump;
 
-static MAKE_RECORDER: OnceCell<MakeRecorder> = OnceCell::new();
+static MAKE_RECORDER: OnceLock<MakeRecorder> = OnceLock::new();
 
 type MakeRecorder = Box<dyn Fn(&'static str) -> Arc<dyn Recorder> + Sync + Send>;
 

--- a/elfo-core/src/message/lookup.rs
+++ b/elfo-core/src/message/lookup.rs
@@ -56,15 +56,15 @@ impl MessageVTable {
 
 #[cfg(not(miri))]
 mod vtables_map {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use super::*;
 
-    pub(super) struct VTablesMap(Lazy<FxHashMap<Signature, &'static MessageVTable>>);
+    pub(super) struct VTablesMap(LazyLock<FxHashMap<Signature, &'static MessageVTable>>);
 
     impl VTablesMap {
         pub(super) const fn new() -> Self {
-            let inner: Lazy<_> = Lazy::new(|| {
+            let inner: LazyLock<_> = LazyLock::new(|| {
                 MESSAGE_VTABLES_LIST
                     .iter()
                     .map(|vtable| (Signature([vtable.protocol, vtable.name]), *vtable))

--- a/elfo-dumper/Cargo.toml
+++ b/elfo-dumper/Cargo.toml
@@ -22,14 +22,14 @@ metrics.workspace = true
 bytesize.workspace = true
 eyre.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "sync"] }
-serde = { version = "1.0.120", features = ["derive"] }
-tracing = "0.1.25"
+serde.workspace = true
+libc.workspace = true
+thread_local.workspace = true
+parking_lot.workspace = true
+tracing.workspace = true
 fxhash = "0.2.1"
 humantime-serde = "1"
 serde_json = "1.0.64"
-parking_lot = "0.12"
-thread_local = "1.1.3"
-libc = "0.2.169"
 
 [dev-dependencies]
 elfo-core = { version = "0.2.0-alpha.20", path = "../elfo-core", features = ["test-util"] }

--- a/elfo-logger/Cargo.toml
+++ b/elfo-logger/Cargo.toml
@@ -25,19 +25,18 @@ metrics.workspace = true
 dashmap.workspace = true
 derive_more.workspace = true
 tokio = { workspace = true, features = ["macros", "fs", "io-util"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "parking_lot"] }
+bytesize.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+tracing.workspace = true
 arc-swap = "1.2.0"
-once_cell = { version = "1.8.0", features = ["parking_lot"] }
 futures-intrusive = "0.5"
-serde = { version = "1.0.120", features = ["derive"] }
-parking_lot = "0.12"
 sharded-slab = "0.1.7"
-tracing = "0.1.25"
-tracing-subscriber = { version = "0.3.2", features = ["env-filter", "parking_lot"] }
 tracing-log = { version = "0.2", optional = true }
 log = { version = "0.4.20", optional = true }
 fxhash = "0.2.1"
 humantime = "2.1.0"
-bytesize.workspace = true
 
 [dev-dependencies]
 elfo-core = { version = "0.2.0-alpha.20", path = "../elfo-core", features = ["test-util"] }

--- a/elfo-logger/src/filtering_layer.rs
+++ b/elfo-logger/src/filtering_layer.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
+#[cfg(feature = "tracing-log")]
+use std::sync::OnceLock;
 
 use arc_swap::ArcSwap;
 use fxhash::FxHashMap;
-#[cfg(feature = "tracing-log")]
-use once_cell::sync::OnceCell;
 use tracing::{metadata::LevelFilter, subscriber::Interest, Metadata, Subscriber};
 use tracing_subscriber::{
     filter::Targets,
@@ -30,7 +30,7 @@ impl Default for FilteringConfig {
 struct Inner {
     config: ArcSwap<FilteringConfig>,
     #[cfg(feature = "tracing-log")]
-    log_metadata_name: OnceCell<&'static str>,
+    log_metadata_name: OnceLock<&'static str>,
 }
 
 #[derive(Clone)]
@@ -44,7 +44,7 @@ impl FilteringLayer {
             inner: Arc::new(Inner {
                 config: ArcSwap::new(Arc::new(FilteringConfig::default())),
                 #[cfg(feature = "tracing-log")]
-                log_metadata_name: OnceCell::new(),
+                log_metadata_name: OnceLock::new(),
             }),
         }
     }

--- a/elfo-macros-impl/Cargo.toml
+++ b/elfo-macros-impl/Cargo.toml
@@ -15,6 +15,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-proc-macro2 = "1.0.24"
-quote = "1.0.9"
-syn = { version = "2", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.75"
+quote = "1.0.35"
+syn = { version = "2.0.52", features = ["full", "extra-traits"] }

--- a/elfo-macros/Cargo.toml
+++ b/elfo-macros/Cargo.toml
@@ -20,4 +20,4 @@ proc-macro = true
 [dependencies]
 elfo-macros-impl = { version = "=0.2.0-alpha.20", path = "../elfo-macros-impl" }
 
-syn = { version = "2", features = ["parsing", "printing"] }
+syn = { version = "2.0.52", features = ["parsing", "printing"] }

--- a/elfo-network/Cargo.toml
+++ b/elfo-network/Cargo.toml
@@ -25,22 +25,22 @@ metrics.workspace = true
 dashmap.workspace = true
 derive_more.workspace = true
 eyre.workspace = true
-serde = { version = "1.0.120", features = ["derive"] }
+serde.workspace = true
+tokio = { workspace = true, features = ["net", "io-util"] }
+futures.workspace = true
+libc.workspace = true
+parking_lot.workspace = true
+slotmap.workspace = true
+pin-project.workspace = true
+tracing.workspace = true
 static_assertions = "1.1.0"
 fxhash = "0.2.1"
-futures = "0.3.21"
-tokio = { workspace = true, features = ["net", "io-util"] }
-tracing = "0.1.25"
-parking_lot = "0.12"
 humantime-serde = "1"
 kanal = "0.1.1"
 bitflags = "2.3.2"
 lz4_flex = { version = "0.11.1", default-features = false, features = ["std"] }
 byteorder = "1.4.3"
 turmoil06 = { package = "turmoil", version = "0.6", optional = true }
-slotmap.workspace = true
-pin-project.workspace = true
-libc = "0.2.160"
 
 [dev-dependencies]
 tracing-test = "0.2.4" # TODO: actually unused?

--- a/elfo-pinger/Cargo.toml
+++ b/elfo-pinger/Cargo.toml
@@ -19,6 +19,6 @@ elfo-core = { version = "0.2.0-alpha.20", path = "../elfo-core", features = ["un
 elfo-utils = { version = "0.2.7", path = "../elfo-utils" }
 
 tokio = { workspace = true, features = ["time"] }
-serde = { version = "1.0.120", features = ["derive"] }
+serde.workspace = true
+tracing.workspace = true
 humantime-serde = "1"
-tracing = "0.1.25"

--- a/elfo-telemeter/Cargo.toml
+++ b/elfo-telemeter/Cargo.toml
@@ -27,15 +27,15 @@ elfo-core = { version = "0.2.0-alpha.20", path = "../elfo-core", features = ["un
 stability.workspace = true
 metrics.workspace = true
 tokio = { workspace = true, features = ["net"] }
-hyper = { version = "1.0.1", features = ["server", "http1"] }
+thread_local.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+tracing.workspace = true
+hyper = { version = "1.1", features = ["server", "http1"] }
 hyper-util = { version = "0.1.3", features = ["tokio"] }
 http-body-util = "0.1"
-serde = { version = "1.0.120", features = ["derive"] }
-sketches-ddsketch = "0.3.0"
+sketches-ddsketch = "0.3"
 seqlock = "0.2"
-thread_local = "1.1.8"
-tracing = "0.1.25"
-parking_lot = "0.12"
 fxhash = "0.2.1"
 humantime-serde = "1"
 cow-utils = "0.1.2"

--- a/elfo-test/Cargo.toml
+++ b/elfo-test/Cargo.toml
@@ -23,8 +23,7 @@ elfo-configurer = { version = "0.2.0-alpha.20", path = "../elfo-configurer" }
 
 tokio.workspace = true
 stability.workspace = true
-serde = { version = "1.0.120", features = ["derive", "rc"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+serde.workspace = true
 serde-value = "0.7.0"
 futures-intrusive = "0.5"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-once_cell = { version = "1.8.0" }

--- a/elfo-test/src/proxy.rs
+++ b/elfo-test/src/proxy.rs
@@ -4,14 +4,13 @@ use std::{
     panic::Location,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, LazyLock,
     },
     thread,
     time::Duration,
 };
 
 use futures_intrusive::timer::{LocalTimer, StdClock, TimerService};
-use once_cell::sync::Lazy;
 use serde::{de::Deserializer, Deserialize};
 use serde_value::Value;
 use tokio::{sync::oneshot, task};
@@ -168,8 +167,8 @@ impl Proxy {
     #[track_caller]
     pub fn recv(&mut self) -> impl Future<Output = Envelope> + '_ {
         // We use a separate timer here to avoid interaction with the tokio's timer.
-        static STD_CLOCK: Lazy<StdClock> = Lazy::new(StdClock::new);
-        static TIMER_SERVICE: Lazy<Arc<TimerService>> = Lazy::new(|| {
+        static STD_CLOCK: LazyLock<StdClock> = LazyLock::new(StdClock::new);
+        static TIMER_SERVICE: LazyLock<Arc<TimerService>> = LazyLock::new(|| {
             let timer_service = Arc::new(TimerService::new(&*STD_CLOCK));
             thread::spawn({
                 let timer_service = timer_service.clone();

--- a/elfo/Cargo.toml
+++ b/elfo/Cargo.toml
@@ -41,14 +41,15 @@ metrics.workspace = true
 toml.workspace = true
 derive_more.workspace = true
 tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
+libc.workspace = true
+thread_local.workspace = true
+tracing-subscriber.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+tracing.workspace = true
 anyhow = "1.0.38"
-futures = "0.3.12"
-tracing = "0.1.25"
-tracing-subscriber = "0.3"
-serde = { version = "1.0.120", features = ["derive"] }
 static_assertions = "1.1.0"
-parking_lot = "0.12"
-libc = "0.2.97"
 futures-intrusive = "0.5"
 turmoil = "0.6"
 trybuild = "1.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,11 +18,11 @@ tokio = { workspace = true, features = ["full"] }
 metrics.workspace = true
 toml.workspace = true
 derive_more.workspace = true
+futures.workspace = true
+serde.workspace = true
+tracing.workspace = true
 anyhow = "1.0.40"
-futures = "0.3.12"
-serde = { version = "1.0.120", features = ["derive"] }
 humantime-serde = "1"
-tracing = "0.1.25"
 
 [features]
 test-util = ["elfo/test-util"]


### PR DESCRIPTION
Related to https://github.com/elfo-rs/elfo/pull/172

* Extend the `msrv` job to check against minimal versions of crates
* Update `toml` from 0.8 to 0.9
* Replace `once_cell` with std `LazyLock` and `OnceLock`
* Use `Swatinem/rust-cache`