### PR TITLE
feat: mailbox single consumer

### DIFF
--- a/elfo-core/Cargo.toml
+++ b/elfo-core/Cargo.toml
@@ -56,6 +56,7 @@ regex = "1.6.0"
 unicycle = "0.10.2"
 rmp-serde = { version = "1.1.0", optional = true }
 humantime-serde = "1"
+diatomic-waker = "0.2.3"
 
 [dev-dependencies]
 elfo-utils = { version = "0.2.7", path = "../elfo-utils", features = ["test-util"] }

--- a/elfo-core/src/actor.rs
+++ b/elfo-core/src/actor.rs
@@ -15,9 +15,10 @@ use crate::{
     envelope::Envelope,
     errors::{SendError, TrySendError},
     group::TerminationPolicy,
-    mailbox::{Mailbox, RecvResult, config::MailboxConfig},
+    mailbox::{Mailbox, MailboxConsumer, config::MailboxConfig},
     messages::{ActorStatusReport, Terminate},
     msg,
+    object::{MappedOwnedObject, OwnedObject},
     request_table::RequestTable,
     restarting::RestartPolicy,
     scope,
@@ -104,6 +105,9 @@ impl ActorStartCause {
         matches!(self, ActorStartCause::OnMessage)
     }
 }
+
+/// A [`MailboxConsumer`] projected out of an actor's [`OwnedObject`].
+pub(crate) type OwnedMailboxConsumer = MailboxConsumer<MappedOwnedObject<Mailbox>>;
 
 // === Actor ===
 
@@ -198,12 +202,11 @@ impl Actor {
         Some(envelope)
     }
 
-    pub(crate) async fn recv(&self) -> RecvResult {
-        self.mailbox.recv().await
-    }
-
-    pub(crate) fn try_recv(&self) -> Option<RecvResult> {
-        self.mailbox.try_recv()
+    /// Panics if a consumer is already attached to this actor's mailbox.
+    pub(crate) fn make_consumer(entry: OwnedObject) -> OwnedMailboxConsumer {
+        let mailbox =
+            MappedOwnedObject::map(entry, |obj| &obj.as_actor().expect("actor object").mailbox);
+        MailboxConsumer::new(mailbox)
     }
 
     pub(crate) fn request_table(&self) -> &RequestTable {
@@ -258,9 +261,12 @@ impl Actor {
         drop(control);
 
         if status.kind().is_finished() {
-            self.close();
-            // Drop all messages to release requests immediately.
-            self.mailbox.drop_all();
+            // No-op while the mailbox consumer is alive
+            if !self.mailbox.close_and_try_drain(scope::trace_id()) {
+                error!(
+                    "mailbox cannot be drained after termination, a context outlives the actor; pending requests may hang"
+                );
+            }
             self.finished.set();
         }
 

--- a/elfo-core/src/context.rs
+++ b/elfo-core/src/context.rs
@@ -14,7 +14,7 @@ use elfo_utils::unlikely;
 
 use crate::{
     ActorStatusKind,
-    actor::{Actor, ActorStartInfo},
+    actor::{Actor, ActorStartInfo, OwnedMailboxConsumer},
     actor_status::ActorStatus,
     addr::Addr,
     address_book::AddressBook,
@@ -27,7 +27,7 @@ use crate::{
     mailbox::RecvResult,
     message::{Message, Request},
     messages, msg,
-    object::{BorrowedObject, Object, OwnedObject},
+    object::{BorrowedObject, MappedOwnedObject, Object},
     request_table::ResponseToken,
     restarting::RestartPolicy,
     routers::Singleton,
@@ -44,7 +44,8 @@ static DUMPER: LazyLock<Dumper> = LazyLock::new(|| Dumper::new(INTERNAL_CLASS));
 /// An actor execution context.
 pub struct Context<C = (), K = Singleton> {
     book: AddressBook,
-    actor: Option<OwnedObject>, // `None` for group's and pruned context.
+    actor: Option<MappedOwnedObject<Actor>>,
+    consumer: Option<OwnedMailboxConsumer>,
     actor_addr: Addr,
     actor_start_info: Option<ActorStartInfo>, // `None` for group's context,
     group_addr: Addr,
@@ -109,7 +110,7 @@ impl<C, K> Context<C, K> {
     /// # }
     /// ```
     pub fn set_status(&self, status: ActorStatus) {
-        ward!(self.actor.as_ref().and_then(|o| o.as_actor())).set_status(status);
+        ward!(self.actor.as_deref()).set_status(status);
     }
 
     /// Gets the actor's status kind.
@@ -130,10 +131,8 @@ impl<C, K> Context<C, K> {
     /// Panics when called on pruned context.
     pub fn status_kind(&self) -> ActorStatusKind {
         self.actor
-            .as_ref()
+            .as_deref()
             .expect("called `status_kind()` on pruned context")
-            .as_actor()
-            .expect("invariant")
             .status_kind()
     }
 
@@ -154,8 +153,7 @@ impl<C, K> Context<C, K> {
     /// # }
     /// ```
     pub fn set_mailbox_capacity(&self, capacity: impl Into<Option<usize>>) {
-        ward!(self.actor.as_ref().and_then(|o| o.as_actor()))
-            .set_mailbox_capacity_override(capacity.into());
+        ward!(self.actor.as_deref()).set_mailbox_capacity_override(capacity.into());
     }
 
     /// Overrides the group's default restart policy, which set in the config.
@@ -175,7 +173,7 @@ impl<C, K> Context<C, K> {
     /// # }
     /// ```
     pub fn set_restart_policy(&self, policy: impl Into<Option<RestartPolicy>>) {
-        ward!(self.actor.as_ref().and_then(|o| o.as_actor())).set_restart_policy(policy.into());
+        ward!(self.actor.as_deref()).set_restart_policy(policy.into());
     }
 
     /// Closes the mailbox, that leads to returning `None` from `recv()` and
@@ -183,7 +181,7 @@ impl<C, K> Context<C, K> {
     ///
     /// Returns `true` if the mailbox has just been closed.
     pub fn close(&self) -> bool {
-        ward!(self.actor.as_ref().and_then(|o| o.as_actor()), return false).close()
+        ward!(self.actor.as_deref(), return false).close()
     }
 
     /// Sends a message using the [inter-group routing] system.
@@ -707,7 +705,7 @@ impl<C, K> Context<C, K> {
             self.pre_recv().await;
 
             let envelope = 'received: {
-                let mailbox_fut = self.actor.as_ref()?.as_actor()?.recv();
+                let mailbox_fut = self.consumer.as_mut()?.recv();
                 pin_mut!(mailbox_fut);
 
                 tokio::select! {
@@ -717,7 +715,7 @@ impl<C, K> Context<C, K> {
                         },
                         RecvResult::Closed(trace_id) => {
                             scope::set_trace_id(trace_id);
-                            let actor = self.actor.as_ref()?.as_actor()?;
+                            let actor = self.actor.as_deref()?;
                             on_input_closed(&mut self.stage, actor);
                             return None;
                         }
@@ -797,18 +795,16 @@ impl<C, K> Context<C, K> {
             self.pre_recv().await;
 
             let envelope = 'received: {
-                let actor = ward!(
-                    self.actor.as_ref().and_then(|o| o.as_actor()),
-                    return Err(TryRecvError::Closed)
-                );
+                let consumer = ward!(self.consumer.as_mut(), return Err(TryRecvError::Closed));
 
                 // TODO: poll mailbox and sources fairly.
-                match actor.try_recv() {
+                match consumer.try_recv() {
                     Some(RecvResult::Data(envelope)) => {
                         break 'received envelope;
                     }
                     Some(RecvResult::Closed(trace_id)) => {
                         scope::set_trace_id(trace_id);
+                        let actor = self.actor.as_deref().expect("actor should be set");
                         on_input_closed(&mut self.stage, actor);
                         return Err(TryRecvError::Closed);
                     }
@@ -879,7 +875,7 @@ impl<C, K> Context<C, K> {
         }
 
         if unlikely(self.stage == Stage::PreRecv) {
-            let actor = ward!(self.actor.as_ref().and_then(|o| o.as_actor()));
+            let actor = ward!(self.actor.as_deref());
             if actor.status_kind().is_initializing() {
                 actor.set_status(ActorStatus::NORMAL);
             }
@@ -960,6 +956,7 @@ impl<C, K> Context<C, K> {
         Context {
             book: self.book.clone(),
             actor: None,
+            consumer: None,
             actor_addr: self.actor_addr,
             actor_start_info: self.actor_start_info.clone(),
             group_addr: self.group_addr,
@@ -982,6 +979,7 @@ impl<C, K> Context<C, K> {
         Context {
             book: self.book,
             actor: self.actor,
+            consumer: self.consumer,
             actor_addr: self.actor_addr,
             actor_start_info: self.actor_start_info,
             group_addr: self.group_addr,
@@ -995,10 +993,15 @@ impl<C, K> Context<C, K> {
     }
 
     pub(crate) fn with_addr(mut self, addr: Addr) -> Self {
-        self.actor = self.book.get_owned(addr);
-        assert!(self.actor.is_some());
+        // Avoids the double-attach panic on re-entry.
+        self.consumer = None;
+        let owned = self.book.get_owned(addr).expect("actor not in book");
         self.actor_addr = addr;
         self.stats = Stats::startup();
+        self.actor = Some(MappedOwnedObject::map(owned.clone(), |obj| {
+            obj.as_actor().expect("actor object")
+        }));
+        self.consumer = Some(Actor::make_consumer(owned));
         self
     }
 
@@ -1016,6 +1019,7 @@ impl<C, K> Context<C, K> {
         Context {
             book: self.book,
             actor: self.actor,
+            consumer: self.consumer,
             actor_addr: self.actor_addr,
             actor_start_info: self.actor_start_info,
             group_addr: self.group_addr,
@@ -1068,6 +1072,7 @@ impl Context {
         Self {
             book,
             actor: None,
+            consumer: None,
             actor_addr: Addr::NULL,
             group_addr: Addr::NULL,
             actor_start_info: None,
@@ -1082,11 +1087,13 @@ impl Context {
 }
 
 // TODO(v0.2): remove this instance.
+// Note: Cloned contexts are send-only.
 impl<C, K: Clone> Clone for Context<C, K> {
     fn clone(&self) -> Self {
         Self {
             book: self.book.clone(),
-            actor: self.book.get_owned(self.actor_addr),
+            actor: self.actor.clone(),
+            consumer: None,
             actor_addr: self.actor_addr,
             actor_start_info: self.actor_start_info.clone(),
             group_addr: self.group_addr,

--- a/elfo-core/src/mailbox.rs
+++ b/elfo-core/src/mailbox.rs
@@ -25,13 +25,18 @@
 //!             └─────────────────────────────────────────────┘
 //! ```
 
-use std::ptr::{self, NonNull};
+use std::{
+    mem,
+    ops::Deref,
+    ptr::{self, NonNull},
+};
 
 use cordyceps::{
     Linked,
     mpsc_queue::{Links, MpscQueue},
 };
-use parking_lot::Mutex;
+use derive_more::IsVariant;
+use parking_lot::{Mutex, MutexGuard};
 use tokio::sync::{Notify, Semaphore, TryAcquireError};
 
 use elfo_utils::CachePadded;
@@ -105,7 +110,8 @@ unsafe impl Linked<Link> for EnvelopeHeader {
     unsafe fn links(ptr: NonNull<Self>) -> NonNull<Link> {
         // Using `ptr::addr_of_mut!` permits us to avoid creating a temporary
         // reference without using layout-dependent casts.
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `EnvelopeHeader`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `EnvelopeHeader`.
         let links = unsafe { ptr::addr_of_mut!((*ptr.as_ptr()).link) };
 
         // SAFETY: `NonNull::new_unchecked` is safe to use here, because the pointer
@@ -137,6 +143,15 @@ struct Control {
     closed_trace_id: Option<TraceId>,
     /// A real capacity of the mailbox.
     capacity: usize,
+    /// State of the single consumer slot.
+    consumer: ConsumerSlot,
+}
+
+/// State of the single consumer slot of a [`Mailbox`].
+#[derive(IsVariant)]
+enum ConsumerSlot {
+    Vacant,
+    Occupied { drain_on_drop: bool },
 }
 
 impl Mailbox {
@@ -150,6 +165,7 @@ impl Mailbox {
             control: Mutex::new(Control {
                 closed_trace_id: None,
                 capacity,
+                consumer: ConsumerSlot::Vacant,
             }),
         }
     }
@@ -223,37 +239,6 @@ impl Mailbox {
         Ok(())
     }
 
-    pub(crate) async fn recv(&self) -> RecvResult {
-        loop {
-            // TODO: it should be possible to use `dequeue_unchecked()` here.
-            // Preliminarily, we should guarantee that it can be called only
-            // by one consumer. However, it's not enough to create a dedicated
-            // `MailboxConsumer` because users can steal `Context` to another
-            // task/thread and create a race with the `drop_all()` method.
-            if let Some(envelope) = self.queue.dequeue() {
-                self.tx_semaphore.add_permits(1);
-                return RecvResult::Data(envelope);
-            }
-
-            if self.tx_semaphore.is_closed() {
-                return self.on_close();
-            }
-
-            self.rx_notify.notified().await;
-        }
-    }
-
-    pub(crate) fn try_recv(&self) -> Option<RecvResult> {
-        match self.queue.dequeue() {
-            Some(envelope) => {
-                self.tx_semaphore.add_permits(1);
-                Some(RecvResult::Data(envelope))
-            }
-            None if self.tx_semaphore.is_closed() => Some(self.on_close()),
-            None => None,
-        }
-    }
-
     #[cold]
     pub(crate) fn close(&self, trace_id: TraceId) -> bool {
         // NOTE: It is important that we take the lock here before actually closing the
@@ -261,7 +246,27 @@ impl Mailbox {
         // possible when we try to `recv()` after the channel is closed, but
         // before the `closed_trace_id` is assigned.
         let mut control = self.control.lock();
+        self.close_inner(&mut control, trace_id)
+    }
 
+    /// Closes the mailbox. Drains the queue inline if no consumer is attached
+    /// (returns `true`); otherwise defers the drain to the consumer's detach
+    /// (returns `false`).
+    #[cold]
+    pub(crate) fn close_and_try_drain(&self, trace_id: TraceId) -> bool {
+        let mut control = self.control.lock();
+        self.close_inner(&mut control, trace_id);
+        if control.consumer.is_vacant() {
+            while self.queue.dequeue().is_some() {}
+            return true;
+        }
+        control.consumer = ConsumerSlot::Occupied {
+            drain_on_drop: true,
+        };
+        false
+    }
+
+    fn close_inner(&self, control: &mut MutexGuard<'_, Control>, trace_id: TraceId) -> bool {
         if self.tx_semaphore.is_closed() {
             return false;
         }
@@ -272,22 +277,79 @@ impl Mailbox {
         self.rx_notify.notify_one();
         true
     }
+}
 
-    #[cold]
-    pub(crate) fn drop_all(&self) {
-        while self.queue.dequeue().is_some() {}
+// === MailboxConsumer ===
+
+/// The unique consumer half of a [`Mailbox`].
+///
+/// Single-consumer is enforced at runtime via `Control::consumer`.
+pub(crate) struct MailboxConsumer<D: Deref<Target = Mailbox>>(D);
+
+impl<D: Deref<Target = Mailbox>> MailboxConsumer<D> {
+    /// Panics if a `MailboxConsumer` is already attached to `inner`.
+    pub(crate) fn new(inner: D) -> Self {
+        let mut control = inner.control.lock();
+        assert!(
+            control.consumer.is_vacant(),
+            "a `MailboxConsumer` is already attached to this mailbox"
+        );
+        control.consumer = ConsumerSlot::Occupied {
+            drain_on_drop: false,
+        };
+        drop(control);
+        Self(inner)
+    }
+
+    pub(crate) async fn recv(&mut self) -> RecvResult {
+        loop {
+            if let Some(envelope) = self.0.queue.dequeue() {
+                self.0.tx_semaphore.add_permits(1);
+                return RecvResult::Data(envelope);
+            }
+
+            if self.0.tx_semaphore.is_closed() {
+                return self.on_close();
+            }
+
+            self.0.rx_notify.notified().await;
+        }
+    }
+
+    pub(crate) fn try_recv(&mut self) -> Option<RecvResult> {
+        match self.0.queue.dequeue() {
+            Some(envelope) => {
+                self.0.tx_semaphore.add_permits(1);
+                Some(RecvResult::Data(envelope))
+            }
+            None if self.0.tx_semaphore.is_closed() => Some(self.on_close()),
+            None => None,
+        }
     }
 
     #[cold]
     fn on_close(&self) -> RecvResult {
         // Some messages may be in the queue after the channel is closed.
-        match self.queue.dequeue() {
+        match self.0.queue.dequeue() {
             Some(envelope) => RecvResult::Data(envelope),
             None => {
-                let control = self.control.lock();
+                let control = self.0.control.lock();
                 let trace_id = control.closed_trace_id.expect("called before close()");
                 RecvResult::Closed(trace_id)
             }
+        }
+    }
+}
+
+impl<D: Deref<Target = Mailbox>> Drop for MailboxConsumer<D> {
+    fn drop(&mut self) {
+        let mut control = self.0.control.lock();
+        let slot = mem::replace(&mut control.consumer, ConsumerSlot::Vacant);
+        if let ConsumerSlot::Occupied {
+            drain_on_drop: true,
+        } = slot
+        {
+            while self.0.queue.dequeue().is_some() {}
         }
     }
 }

--- a/elfo-core/src/mailbox.rs
+++ b/elfo-core/src/mailbox.rs
@@ -26,9 +26,11 @@
 //! ```
 
 use std::{
+    future::poll_fn,
     mem,
     ops::Deref,
     ptr::{self, NonNull},
+    task::Poll,
 };
 
 use cordyceps::{
@@ -36,8 +38,9 @@ use cordyceps::{
     mpsc_queue::{Links, MpscQueue},
 };
 use derive_more::IsVariant;
+use diatomic_waker::DiatomicWaker;
 use parking_lot::{Mutex, MutexGuard};
-use tokio::sync::{Notify, Semaphore, TryAcquireError};
+use tokio::sync::{Semaphore, TryAcquireError};
 
 use elfo_utils::CachePadded;
 
@@ -89,9 +92,10 @@ assert_not_impl_any!(EnvelopeHeader: Unpin);
 
 // SAFETY:
 // * `EnvelopeHeader` is pinned in memory while it is in the queue, the only way
-//   to access inserted `EnvelopeHeader` is by using the `dequeue()` method.
+//   to access inserted `EnvelopeHeader` is by using the `dequeue_unchecked()`
+//   method.
 // * `EnvelopeHeader` cannot be deallocated without prunning the queue, which is
-//   done also by calling `dequeue()` method multiple times.
+//   done also by calling `dequeue_unchecked()` method multiple times.
 // * `EnvelopeHeader` doesn't implement `Unpin` (checked statically above).
 unsafe impl Linked<Link> for EnvelopeHeader {
     // It would be nice to enforce pinning here by using `Pin<Envelope>`.
@@ -130,9 +134,9 @@ pub(crate) struct Mailbox {
     // TODO: replace with a custom semaphore based on `async-event` (10-15% faster).
     tx_semaphore: Semaphore,
 
-    /// A notifier of a receiver about the availability of new messages.
-    // TODO: replace with `diatomic-waker` (3-5% faster).
-    rx_notify: CachePadded<Notify>,
+    /// Wakes the consumer when a new envelope is enqueued or the
+    /// mailbox is closed.
+    rx_waker: CachePadded<DiatomicWaker>,
 
     /// Use `Mutex` here for synchronization on close/configure.
     control: Mutex<Control>,
@@ -161,7 +165,7 @@ impl Mailbox {
         Self {
             queue: MpscQueue::new_with_stub(Envelope::stub()),
             tx_semaphore: Semaphore::new(capacity),
-            rx_notify: CachePadded::new(Notify::new()),
+            rx_waker: CachePadded::new(DiatomicWaker::new()),
             control: Mutex::new(Control {
                 closed_trace_id: None,
                 capacity,
@@ -201,7 +205,7 @@ impl Mailbox {
 
         permit.forget();
         self.queue.enqueue(envelope);
-        self.rx_notify.notify_one();
+        self.rx_waker.notify();
         Ok(())
     }
 
@@ -210,7 +214,7 @@ impl Mailbox {
             Ok(permit) => {
                 permit.forget();
                 self.queue.enqueue(envelope);
-                self.rx_notify.notify_one();
+                self.rx_waker.notify();
                 Ok(())
             }
             Err(TryAcquireError::NoPermits) => Err(TrySendError::Full(envelope)),
@@ -234,7 +238,7 @@ impl Mailbox {
         }
 
         self.queue.enqueue(envelope);
-        self.rx_notify.notify_one();
+        self.rx_waker.notify();
 
         Ok(())
     }
@@ -257,7 +261,8 @@ impl Mailbox {
         let mut control = self.control.lock();
         self.close_inner(&mut control, trace_id);
         if control.consumer.is_vacant() {
-            while self.queue.dequeue().is_some() {}
+            // SAFETY: No other consumer is exist at this time.
+            unsafe { while self.queue.dequeue_unchecked().is_some() {} }
             return true;
         }
         control.consumer = ConsumerSlot::Occupied {
@@ -274,7 +279,7 @@ impl Mailbox {
         control.closed_trace_id = Some(trace_id);
 
         self.tx_semaphore.close();
-        self.rx_notify.notify_one();
+        self.rx_waker.notify();
         true
     }
 }
@@ -302,22 +307,29 @@ impl<D: Deref<Target = Mailbox>> MailboxConsumer<D> {
     }
 
     pub(crate) async fn recv(&mut self) -> RecvResult {
-        loop {
-            if let Some(envelope) = self.0.queue.dequeue() {
-                self.0.tx_semaphore.add_permits(1);
-                return RecvResult::Data(envelope);
+        poll_fn(|cx| {
+            if let Some(result) = self.try_recv() {
+                return Poll::Ready(result);
             }
-
-            if self.0.tx_semaphore.is_closed() {
-                return self.on_close();
+            // SAFETY: `MailboxConsumer` is the sole sink of `rx_waker`.
+            unsafe { self.0.rx_waker.register(cx.waker()) };
+            // Recheck to avoid a lost wake-up between the first `try_recv`
+            // and our `register`.
+            match self.try_recv() {
+                Some(result) => {
+                    // SAFETY: see `register` above.
+                    unsafe { self.0.rx_waker.unregister() };
+                    Poll::Ready(result)
+                }
+                None => Poll::Pending,
             }
-
-            self.0.rx_notify.notified().await;
-        }
+        })
+        .await
     }
 
     pub(crate) fn try_recv(&mut self) -> Option<RecvResult> {
-        match self.0.queue.dequeue() {
+        // SAFETY: sole consumer invariant — see [`MailboxConsumer`].
+        match unsafe { self.0.queue.dequeue_unchecked() } {
             Some(envelope) => {
                 self.0.tx_semaphore.add_permits(1);
                 Some(RecvResult::Data(envelope))
@@ -330,7 +342,8 @@ impl<D: Deref<Target = Mailbox>> MailboxConsumer<D> {
     #[cold]
     fn on_close(&self) -> RecvResult {
         // Some messages may be in the queue after the channel is closed.
-        match self.0.queue.dequeue() {
+        // SAFETY: sole consumer invariant — see [`MailboxConsumer`].
+        match unsafe { self.0.queue.dequeue_unchecked() } {
             Some(envelope) => RecvResult::Data(envelope),
             None => {
                 let control = self.0.control.lock();
@@ -349,7 +362,8 @@ impl<D: Deref<Target = Mailbox>> Drop for MailboxConsumer<D> {
             drain_on_drop: true,
         } = slot
         {
-            while self.0.queue.dequeue().is_some() {}
+            // SAFETY: No other consumer is exist at this time.
+            unsafe { while self.0.queue.dequeue_unchecked().is_some() {} }
         }
     }
 }

--- a/elfo-core/src/message.rs
+++ b/elfo-core/src/message.rs
@@ -121,7 +121,8 @@ pub trait Message:
     #[doc(hidden)]
     #[inline(always)]
     unsafe fn _read(ptr: NonNull<MessageRepr>) -> Self {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<Self>`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr<Self>`.
         let data_ref = &unsafe { ptr.cast::<MessageRepr<Self>>().as_ref() }.data;
         // SAFETY: `data_ref` points to a properly initialized `Self`.
         unsafe { ptr::read(data_ref) }
@@ -138,7 +139,8 @@ pub trait Message:
     #[inline(always)]
     unsafe fn _write(self, ptr: NonNull<MessageRepr>) {
         let repr = MessageRepr::new(self);
-        // SAFETY: `ptr` is valid for writes and properly aligned for `MessageRepr<Self>`.
+        // SAFETY: `ptr` is valid for writes and properly aligned for
+        // `MessageRepr<Self>`.
         unsafe { ptr::write(ptr.cast::<MessageRepr<Self>>().as_ptr(), repr) };
     }
 }

--- a/elfo-core/src/message/any.rs
+++ b/elfo-core/src/message/any.rs
@@ -298,11 +298,13 @@ impl Message for AnyMessage {
 
     #[inline(always)]
     unsafe fn _read(ptr: NonNull<MessageRepr>) -> Self {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr`.
         let vtable = unsafe { (*ptr.as_ptr()).vtable };
         let this = alloc_repr(vtable);
 
-        // SAFETY: `this` was just allocated with the same layout, so it's valid for writes.
+        // SAFETY: `this` was just allocated with the same layout, so it's valid for
+        // writes.
         unsafe {
             ptr::copy_nonoverlapping(
                 ptr.cast::<u8>().as_ptr(),

--- a/elfo-core/src/message/repr.rs
+++ b/elfo-core/src/message/repr.rs
@@ -203,9 +203,11 @@ mod vtablefns {
         ptr: NonNull<MessageRepr>,
         out_ptr: NonNull<MessageRepr>,
     ) {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<M>`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr<M>`.
         let cloned = unsafe { ptr.cast::<MessageRepr<M>>().as_ref() }.clone();
-        // SAFETY: `out_ptr` is valid for writes and properly aligned for `MessageRepr<M>`.
+        // SAFETY: `out_ptr` is valid for writes and properly aligned for
+        // `MessageRepr<M>`.
         unsafe { ptr::write(out_ptr.cast::<MessageRepr<M>>().as_ptr(), cloned) };
     }
 
@@ -216,7 +218,8 @@ mod vtablefns {
         ptr: NonNull<MessageRepr>,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<M>`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr<M>`.
         let data = &unsafe { ptr.cast::<MessageRepr<M>>().as_ref() }.data;
         fmt::Debug::fmt(data, f)
     }
@@ -225,7 +228,8 @@ mod vtablefns {
     ///
     /// `ptr` must be valid for reads and point to a `MessageRepr<M>`.
     pub(super) unsafe fn erase<M: Message>(ptr: NonNull<MessageRepr>) -> dumping::ErasedMessage {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<M>`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr<M>`.
         let data = unsafe { ptr.cast::<MessageRepr<M>>().as_ref() }
             .data
             .clone();
@@ -239,7 +243,8 @@ mod vtablefns {
     pub(super) unsafe fn as_serialize_any<M: Message>(
         ptr: NonNull<MessageRepr>,
     ) -> NonNull<dyn erased_serde::Serialize> {
-        // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<M>`.
+        // SAFETY: `ptr` is valid for reads and points to a properly initialized
+        // `MessageRepr<M>`.
         let data = &unsafe { ptr.cast::<MessageRepr<M>>().as_ref() }.data;
         let ser = data as &dyn erased_serde::Serialize;
         // SAFETY: `ser` is a valid reference, so the resulting pointer is non-null.
@@ -254,7 +259,8 @@ mod vtablefns {
         out_ptr: NonNull<MessageRepr>,
     ) -> Result<(), erased_serde::Error> {
         let data = erased_serde::deserialize::<M>(deserializer)?;
-        // SAFETY: `out_ptr` is valid for writes and properly aligned for `MessageRepr<M>`.
+        // SAFETY: `out_ptr` is valid for writes and properly aligned for
+        // `MessageRepr<M>`.
         unsafe {
             ptr::write(
                 out_ptr.cast::<MessageRepr<M>>().as_ptr(),
@@ -273,7 +279,8 @@ mod vtablefns {
             out_ptr: NonNull<MessageRepr>,
         ) -> Result<(), decode::Error> {
             let data = decode::from_slice(buffer)?;
-            // SAFETY: `out_ptr` is valid for writes and properly aligned for `MessageRepr<M>`.
+            // SAFETY: `out_ptr` is valid for writes and properly aligned for
+            // `MessageRepr<M>`.
             unsafe {
                 ptr::write(
                     out_ptr.cast::<MessageRepr<M>>().as_ptr(),
@@ -291,7 +298,8 @@ mod vtablefns {
             out: &mut Vec<u8>,
             limit: usize,
         ) -> Result<(), encode::Error> {
-            // SAFETY: `ptr` is valid for reads and points to a properly initialized `MessageRepr<M>`.
+            // SAFETY: `ptr` is valid for reads and points to a properly initialized
+            // `MessageRepr<M>`.
             let data = &unsafe { ptr.cast::<MessageRepr<M>>().as_ref() }.data;
             let mut out = LimitedWrite(out, limit);
             encode::write_named(&mut out, data)

--- a/elfo-core/src/object.rs
+++ b/elfo-core/src/object.rs
@@ -1,7 +1,9 @@
 use std::{
     future::Future,
     mem,
+    ops::Deref,
     pin::Pin,
+    ptr::NonNull,
     task::{self, Poll},
 };
 
@@ -32,6 +34,51 @@ assert_impl_all!(Object: Sync);
 pub(crate) type BorrowedObject<'g> = BorrowedEntry<'g, Object>;
 // Reexported in `_priv`.
 pub type OwnedObject = OwnedEntry<Object>;
+
+// === MappedOwnedObject ===
+
+/// An [`OwnedObject`] projected to one of its fields.
+pub(crate) struct MappedOwnedObject<P> {
+    projected: NonNull<P>,
+    entry: OwnedObject,
+}
+
+// SAFETY: `Object: Sync` is asserted above; `map`'s forces `P` to be borrowed
+// from `&Object`, so `P` is transitively `Send + Sync`.
+unsafe impl<P> Send for MappedOwnedObject<P> {}
+// SAFETY: Same as above.
+unsafe impl<P> Sync for MappedOwnedObject<P> {}
+
+impl<P> MappedOwnedObject<P> {
+    pub(crate) fn map<F>(entry: OwnedObject, proj: F) -> Self
+    where
+        F: FnOnce(&Object) -> &P,
+    {
+        let projected = NonNull::from(proj(&entry));
+        Self { entry, projected }
+    }
+}
+
+impl<P> Deref for MappedOwnedObject<P> {
+    type Target = P;
+
+    #[inline]
+    fn deref(&self) -> &P {
+        // SAFETY: `entry` keeps the object alive and `idr_ebr::OwnedEntry`
+        // pins it at a stable heap address, so `projected` remains valid for the
+        // lifetime of `entry`.
+        unsafe { self.projected.as_ref() }
+    }
+}
+
+impl<P> Clone for MappedOwnedObject<P> {
+    fn clone(&self) -> Self {
+        Self {
+            entry: self.entry.clone(),
+            projected: self.projected,
+        }
+    }
+}
 
 #[derive(From)]
 #[allow(clippy::large_enum_variant)]

--- a/elfo-telemeter/src/allocator.rs
+++ b/elfo-telemeter/src/allocator.rs
@@ -61,7 +61,8 @@ where
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        // SAFETY: `ptr` was returned by a prior call to `alloc`/`realloc` with `layout`.
+        // SAFETY: `ptr` was returned by a prior call to `alloc`/`realloc` with
+        // `layout`.
         let ptr = unsafe { self.inner.realloc(ptr, layout, new_size) };
         if !ptr.is_null() {
             elfo_core::scope::try_with(|scope| {

--- a/elfo/tests/restarting.rs
+++ b/elfo/tests/restarting.rs
@@ -140,10 +140,15 @@ impl Drop for GuardedMessage {
 // See #68.
 #[tokio::test(start_paused = true)]
 async fn mailbox_must_be_dropped() {
-    let blueprint = ActorGroup::new().exec(|_ctx| async {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        anyhow::bail!("boom!");
-    });
+    let blueprint = ActorGroup::new()
+        .restart_policy(RestartPolicy::on_failure(RestartParams::new(
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+        )))
+        .exec(|_ctx| async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            anyhow::bail!("boom!");
+        });
     let proxy = elfo::test::proxy(blueprint, elfo::config::AnyConfig::default()).await;
 
     let msg = GuardedMessage::default();

--- a/elfo/tests/termination.rs
+++ b/elfo/tests/termination.rs
@@ -1,12 +1,15 @@
 #![allow(missing_docs)]
 #![cfg(feature = "test-util")]
 #![allow(clippy::never_loop)]
+use std::{pin::pin, time::Duration};
 
 use elfo::{
     TerminationPolicy,
-    messages::{Terminate, TerminateReason},
+    messages::{Ping, Terminate, TerminateReason},
     prelude::*,
 };
+use futures::poll;
+use tokio::time::sleep;
 
 #[message]
 #[derive(PartialEq)]
@@ -108,6 +111,49 @@ async fn terminate_with_reason() {
         .await;
     assert_msg_eq!(proxy.recv().await, TerminateResponse(reason));
     assert!(proxy.try_recv().await.is_none());
+}
+
+// A `Context` leaked into a detached task outlives the actor's `exec` future.
+// While the context is alive, the mailbox cannot be drained, so pending
+// requests stay unresolved past actor termination.
+#[tokio::test]
+async fn context_outlives_actor() {
+    tokio::time::pause();
+
+    let blueprint = ActorGroup::new()
+        .termination_policy(TerminationPolicy::manually())
+        .exec(move |ctx| async move {
+            // `exec` returns at t=1s, but the spawned task keeps the context
+            // alive until t=6s.
+            sleep(std::time::Duration::from_secs(1)).await;
+            // Steal context and extend its live
+            tokio::spawn(async move {
+                let _ctx = ctx;
+                sleep(std::time::Duration::from_secs(5)).await;
+            });
+        });
+    let mut proxy = elfo::test::proxy(blueprint, elfo::config::AnyConfig::default()).await;
+
+    // Issue a request that nobody will read from the mailbox.
+    let requester = proxy.subproxy().await;
+    let mut fut = pin!(requester.request_fallible(Ping::default()));
+    assert!(poll!(&mut fut).is_pending());
+
+    // t=2s: `exec` has returned, the actor is in a finished state.
+    tokio::time::advance(Duration::from_secs(2)).await;
+    proxy.sync().await;
+
+    // The mailbox is closed for new producers.
+    assert!(proxy.try_send(Ping::default()).is_err());
+    // But the in-flight request still hangs: the leaked context blocks
+    // mailbox draining, so pending requests are not resolved yet.
+    assert!(poll!(&mut fut).is_pending());
+
+    // t=8s: the spawned task ends and drops the context. The mailbox is
+    // finally drained, and pending requests resolve with `RequestError`.
+    tokio::time::advance(Duration::from_secs(6)).await;
+    proxy.sync().await;
+    assert!(poll!(&mut fut).is_ready());
 }
 
 #[message]


### PR DESCRIPTION
 ### Changed                                                                                                                            
  - **BREAKING** core/context: `recv`/`try_recv` now live on a move-only `MailboxConsumer` acquired once per spawn; cloned `Context`s are send-only.                                                                                             
  - core/mailbox: swap `tokio::Notify` → `DiatomicWaker` and `MpscQueue::dequeue` → `dequeue_unchecked`; −5…−6.5% on  `one_to_one/send_{routed,direct}` at 4+ producers, 1p1c unchanged except `send_direct` +4.6% (Xeon Gold 6526Y, SNC2). 
  
  See https://gist.github.com/sargarass/362a9cc3c7d1722eef50e979b92041be